### PR TITLE
Add missing import

### DIFF
--- a/tkp/utility/accessors/fitsimage.py
+++ b/tkp/utility/accessors/fitsimage.py
@@ -1,4 +1,4 @@
-
+import datetime
 from tkp.utility.accessors import DataAccessor
 import pyfits
 import numpy


### PR DESCRIPTION
Fixing bug reported in e-mail by Hugh Garsden:

> I'm getting an error when running Pyse on heastro1:
> 
> hgarsden@heastro1:~$ /opt/tkp/dev/tkp/bin/pyse SB44.8.fits 
> Processing SB44.8.fits (file 1 of 1).
> WARNING:root:Frequency not specified in FITS
> WARNING:root:Timestamp not specified in FITS file; using now
> Traceback (most recent call last):
> File "/opt/tkp/dev/tkp/bin/pyse.py", line 216, in <module>
>   print run_sourcefinder(files, options),
> File "/opt/tkp/dev/tkp/bin/pyse.py", line 178, in run_sourcefinder
>   ff = FitsFile(filename, plane=0)
> File "/opt/tkp/dev/tkp/lib/python/tkp/utility/accessors/fitsimage.py", line 80, in **init**
>   self.utc = datetime.datetime.now().replace(tzinfo=pytz.utc)
> NameError: global name 'datetime' is not defined
