### PR TITLE
Ensure build takes place within our build dir

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,7 @@
-# This is a not-ideal solution to the problem that Python 
-# does not really do out-of-source builds.
-# Ie, one can specify build-base on the command line when
-#  building the package, but that apparently can't be used 
-# when installing the package
+# This is a not-ideal solution to the problem that Python does not really do
+# out-of-source builds.  Ie, one can specify build-base on the command line
+# when building the package, but that apparently can't be used when installing
+# the package
 
 [build]
-build-base=../build/tkp/python-packages
+build-base=build/tkp/python-packages


### PR DESCRIPTION
Formerly, if I did:

```
$ mkdir build && cd build
$ cmake .. && make && make install
```

I would end up with a directory `../../build` containing the tkp python module.
That doesn't make any sense -- it should be within the local build directory,
not somewhere else on the filesystem.
