### PR TITLE
Fix failing unit test (test_monitored_source_insertion).

### DIFF
--- a/tests/db_queries.py
+++ b/tests/db_queries.py
@@ -17,6 +17,8 @@ from tkp.config import config
 def count_runcat_entries(conn, dataset):
     """Count the number of runningcatalog sources
     for a specific dataset
+    
+    Returns an integer.
     """
 
     try:
@@ -27,7 +29,7 @@ def count_runcat_entries(conn, dataset):
          WHERE dataset = %s
         """
         cursor.execute(query, (dataset,))
-        runcat_count = cursor.fetchall()
+        runcat_count = cursor.fetchall()[0][0]
         if not config['database']['autocommit']:
             conn.commit()
         cursor.close()
@@ -39,6 +41,9 @@ def count_runcat_entries(conn, dataset):
 def count_associated_sources(conn, dataset):
     """Count the number of associations for runningcatalog sources
     for a specific dataset
+    
+    Returns: A list of pairwise tuples,
+         [ (assoc_src_id, assocs_count) ]
     """
 
     try:

--- a/tests/test_database/test_monitoringlist.py
+++ b/tests/test_database/test_monitoringlist.py
@@ -184,9 +184,9 @@ class TestTransientCandidateMonitoring(unittest.TestCase):
             mon_results = [ (s[2],s[3],m) for  s,m in zip(srcs_to_monitor, mon_extractions)] 
             dbimg.insert_monitored_sources(mon_results)
 #       
-        runcat_entries = dbq.count_runcat_entries(self.database.connection, self.dataset.id)
+        n_runcat_entries = dbq.count_runcat_entries(self.database.connection, self.dataset.id)
 #        print "Runcat rows:", runcat_rows
-        self.assertEqual(len(runcat_entries), 4)
+        self.assertEqual(n_runcat_entries, 4)
         assoc_counts = dbq.count_associated_sources(self.database.connection, self.dataset.id)
         for count in assoc_counts:
             self.assertEqual(count[1], 8)


### PR DESCRIPTION
I perhaps should have caught this one, but it looked ok at first glance!

NB to run all the unit tests you need

[test]
long = True

in your tkp.cfg.

You can run just a specific set of tests via e.g.
nosetests  path/to/sometest.py

If you just want to retest one failing suite.
