### PR TITLE
Update runtests.py: MonetDB log suppression, output default datapath if used.

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -31,11 +31,13 @@ Default path to TKP test data: {0}
     if args[1].find("--datapath=")!=-1: #args[0] is script name
         datapath=args[1][len("--datapath="):]
         return datapath, args[0:1]+args[2:]                
+    else:
+        print "Using default datapath:",datapath
     return datapath, args
 
 if __name__ == "__main__":
     import logging
-    import monetdb.sql
+    import monetdb
     try:
         import tkp.config
     except ImportError:
@@ -43,7 +45,8 @@ if __name__ == "__main__":
         sys.exit(1)
 
     datapath, args = handle_args(sys.argv) 
-    monetdb.sql.logger.setLevel(logging.ERROR) #Suppress MonetDB debug log. 
+    logging.getLogger('monetdb').setLevel(logging.ERROR) #Suppress MonetDB debug log. 
+    logging.getLogger().setLevel(logging.ERROR)
     tkp.config.config['test']['datapath']=datapath
     nose.run(argv=args)
 


### PR DESCRIPTION
If a database error is encountered, the MonetDB log spews out hundreds
of lines of output.
While this may be useful for tricky bugs, it obscures the source of
the bug if you've made a simple syntax error, as you must scroll
up many pages to see the test that failed.

By changing the logger level in the runtests wrapper, we suppress the output
so we can just see the unit tests error messages.
