### PR TITLE
Render maths with MathJax rather than PNGs

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -34,7 +34,7 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
     'sphinx.ext.graphviz',
-    'sphinx.ext.pngmath'
+    'sphinx.ext.mathjax'
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
This looks prettier, and I think there is no downside unless somebody is using a truly antediluvian browser (http://www.mathjax.org/resources/browser-compatibility/).
