### PR TITLE
Add @duration(test_duration) decorator.

### DIFF
--- a/tests/decorators.py
+++ b/tests/decorators.py
@@ -24,3 +24,11 @@ def requires_module(module_name):
     except ImportError:
         return unittest.skip("Required module (%s) not available" % module_name)
     return lambda func: func
+
+def duration(test_duration):
+    if tkp.config.config['test']['max_duration']:
+        if tkp.config.config['test']['max_duration'] < test_duration:
+            return unittest.skip(
+             "Tests of duration > %s disabled in tkp.config['test'] section." % 
+                tkp.config.config['test']['max_duration'])
+    return lambda func: func

--- a/tests/test_database/test_monitoringlist.py
+++ b/tests/test_database/test_monitoringlist.py
@@ -8,7 +8,7 @@ import tests.db_subs as db_subs
 import tests.db_queries as dbq
 from tests.decorators import requires_database         
 
-@unittest.skipIf(not eval(tkp.config.config['test']['long']), "not runnig prolonged test suite")
+
 class TestTransientCandidateMonitoring(unittest.TestCase):
     @requires_database()
     def setUp(self):

--- a/tests/test_database/test_transients.py
+++ b/tests/test_database/test_transients.py
@@ -5,10 +5,9 @@ import tkp.database as tkpdb
 from tkp.classification.transient import Transient
 import tkp.config
 import db_subs
-from decorators import requires_database
+from decorators import requires_database, duration
 
 
-@unittest.skipIf(not eval(tkp.config.config['test']['long']), "not runnig prolonged test suite")
 class TestTransientRoutines(unittest.TestCase):
     @requires_database()
     def setUp(self):

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,53 @@
+import unittest
+if not  hasattr(unittest.TestCase, 'assertIsInstance'):
+    import unittest2 as unittest
+import tkp.config
+import db_subs
+import os
+from decorators import requires_database, requires_data, duration
+
+def debug_print(*args):
+    return #Comment to switch on debug prints.
+    print "**",
+    for a in args:
+        print a,
+    print "**"
+
+
+class TestDatabaseDecorators(unittest.TestCase):
+    @requires_database()
+    def test_requires_database(self):
+        debug_print( "Database testing enabled.")
+        
+        
+class TestDataDecorators(unittest.TestCase):
+    def test_datapath_defined(self):
+        self.assertNotEqual(tkp.config.config['test']['datapath'], None )
+        debug_print( "Test data path:", 
+                     tkp.config.config['test']['datapath'])
+        
+    @requires_data(os.path.join(tkp.config.config['test']['datapath'], 
+                                'CORRELATED_NOISE.FITS'))
+    def test_requires_data_decorator(self):
+        f = open(os.path.join(tkp.config.config['test']['datapath'], 
+                              'CORRELATED_NOISE.FITS'))
+        
+    
+class TestDurationDecorator(unittest.TestCase):
+    def test_max_duration_defined(self):
+        debug_print("Max_duration:", tkp.config.config['test']['max_duration'])
+        debug_print("Max_duration type:", 
+                    type(tkp.config.config['test']['max_duration']))
+        
+    @duration(5)
+    def test_short(self):
+        debug_print("Will run test duration = 5") 
+    @duration(25)
+    def test_medium(self):
+        debug_print("Will run test duration = 25")
+    @duration(300)
+    def test_long(self):
+        debug_print("Will run test duration = 300")
+        
+            
+            

--- a/tests/test_sourcefinder/test_FDR.py
+++ b/tests/test_sourcefinder/test_FDR.py
@@ -40,13 +40,13 @@ import os
 from tkp.utility import accessors
 from tkp.sourcefinder import image
 import tkp.config
-from decorators import requires_data
+from decorators import requires_data, duration
 
 DATAPATH = tkp.config.config['test']['datapath']
 NUMBER_INSERTED = float(3969)
 
 
-@unittest.skipIf(not eval(tkp.config.config['test']['long']), "not runnig prolonged test suite")
+
 class test_maps(unittest.TestCase):
     def setUp(self):
         uncorr_map = accessors.FitsFile(os.path.join(DATAPATH, 'UNCORRELATED_NOISE.FITS'))
@@ -66,6 +66,7 @@ class test_maps(unittest.TestCase):
     @requires_data(os.path.join(DATAPATH, 'UNCORRELATED_NOISE.FITS'))
     @requires_data(os.path.join(DATAPATH, 'CORRELATED_NOISE.FITS'))
     @requires_data(os.path.join(DATAPATH, 'TEST_DECONV.FITS'))
+    @duration(100)
     def testNumSources(self):
         self.assertEqual(self.number_detections_uncorr, 0)
         self.assertEqual(self.number_detections_corr, 0)

--- a/tests/test_sourcefinder/test_source_measurements.py
+++ b/tests/test_sourcefinder/test_source_measurements.py
@@ -33,7 +33,7 @@ TRUE_DECONV_SMIN = 0.5*4.6794/2.
 TRUE_DECONV_BPA = -0.5*(-49.8)
 
 
-@unittest.skipIf(not eval(tkp.config.config['test']['long']), "not runnig prolonged test suite")
+
 class SourceParameters(unittest.TestCase):
 
     def setUp(self):

--- a/tkp/__init__.py
+++ b/tkp/__init__.py
@@ -30,9 +30,4 @@ The division in subpackages follows these steps roughly:
 
 - utility routines
 
-
-
-
-
-
 """

--- a/tkp/config.py
+++ b/tkp/config.py
@@ -168,9 +168,7 @@ def set_default_config():
     config.add_section('test')
     config.set('test', 'datapath', os.path.abspath(os.path.join(testpath[0], "..", "tests", "data")))
     config.set('test', 'test_database_name', 'testdb')
-    config.set('test', 'reset_test_database', 'False')
-    config.set('test', 'long', 'False')
-    config.set('test', 'test_database_dump_dir', 'None')
+    config.set('test', 'max_duration', '0') #Default = 0, implies 'Run all tests'.
     return config
 
 
@@ -242,6 +240,7 @@ def parse_config(config):
                 ('source_extraction', 'deblend_nthresh'),
                 ('transient_search', 'minpoints'),
                 ('alerts', 'port'),
+                ('test', 'max_duration')
                 )
     floats = (('source_association', 'deruiter_radius'),
               ('source_extraction', 'mf_threshold'),


### PR DESCRIPTION
I've added decorator allowing you to specify the expected duration of a test.
This can be measured using e.g. https://github.com/mahmoudimus/nose-timer
(nosetests -svx --with-timer)

You can now specify a 'max_duration' variable in the ['tests']
section of your tkp config file. Tests of longer duration will be skipped.
The default value is zero, which runs _all_ tests.

I've also removed some variables from the tkp.config.config['tests']
section that aren't in use, to avoid confusion.
