### PR TITLE
Replace Levenberg–Marquardt minimization with L-BFGS-B

### DIFF
--- a/tkp/sourcefinder/fitting.py
+++ b/tkp/sourcefinder/fitting.py
@@ -166,7 +166,7 @@ def fitgaussian(data, params, fixed=None):
         else:
             initial.append(params[key])
 
-    for key, value in fixed.keys():
+    for key, value in fixed.iteritems():
         if key not in FIT_PARAMS:
             raise ValueError("Fixed parameter %s not recognized" % key)
         index = FIT_PARAMS.index(key)


### PR DESCRIPTION
See #3843 for a full discussion: it probably shouldn't be merged until there's a consensus there, but I am opening this pull request now so you can see exactly what we're talking about.

This is basically a rewrite of `tkp.sourcefinder.fitting.fitgaussian()`. It retains almost exactly the same API, except that I've dropped the `maxfev` argument: I couldn't find any code which actually used this.
