### PR TITLE
Relax leastsq tolerances

### DIFF
--- a/tkp/sourcefinder/fitting.py
+++ b/tkp/sourcefinder/fitting.py
@@ -200,8 +200,14 @@ def fitgaussian(data, params, fixed=None, maxfev=0):
         return (gaussian(*gaussian_args)(*numpy.indices(data.shape)) -
                 data ).compressed()
 
+    # maxfev=0, the default, corresponds to 200*(N+1) (NB, not 100*(N+1) as
+    # the scipy docs state!) function evaluations, where N is the number of
+    # parametrs in the solution.
+    # Convergence tolerances xtol and ftol established by experiment on images
+    # from Paul Hancock's simulations.
     solution, icov_x, infodict, mesg, success = scipy.optimize.leastsq(
-        errorfunction, my_pars, fixed, full_output=True, maxfev=maxfev
+        errorfunction, my_pars, fixed, full_output=True, maxfev=maxfev,
+        xtol=1e-4, ftol=1e-4
     )
 
     # solution contains only the variable parameters; we need to merge the


### PR DESCRIPTION
xtol and ftol control when the leastsq algorithm is regarded as having
converged. See
http://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.leastsq.html
for details.

Until now, we have been using the default values (1.49012e-08 for both). When
testing against Hancock's images
http://www.physics.usyd.edu.au/~hancock/index.php/Data/SourceFindingSimulation,
I saw a large number of failures (~400 of ~10000 fits) where the fit simply
didn't converge to an acceptable solution, so I experimented with relaxing
these parameters.

This changes sets them both to 1e-4. By experiment, this makes no difference
to the fitted fluxes I recover from Hancock's images (I go from the
mean/median/stddev of the flux differences being 0.000478/0.000023/0.023992 to
0.000437/0.000025/0.023268), but reduces the number of convergence failures to
zero.
