### PR TITLE
Pull accessor classes into tkp.utility.accessors namespace.

### DIFF
--- a/tkp/utility/accessors/__init__.py
+++ b/tkp/utility/accessors/__init__.py
@@ -14,6 +14,9 @@ import numpy
 from tkp.database import Image as DBImage
 from tkp.sourcefinder.image import ImageData
 import tkp.utility.accessors.detection
+from tkp.utility.accessors.dataaccessor import DataAccessor
+from tkp.utility.accessors.fitsimage import FitsImage
+from tkp.utility.accessors.casaimage import CasaImage
 
 
 def dbimage_from_accessor(dataset, image):


### PR DESCRIPTION
E.g. FitsImage is defined in a module of its own,
but it's tiresome to write tkp.utility.accessors.fitsimage.FitsImage.

NB pull request fixing broken tkp-web calls coming up...
