### PR TITLE
A buggy: Version number must be equal to highest upgrade value.

### DIFF
--- a/database/sql/tables/version.sql
+++ b/database/sql/tables/version.sql
@@ -4,6 +4,6 @@ CREATE TABLE version
   ,PRIMARY KEY(name)
 );
 
-INSERT INTO version (name, value) VALUES ('revision', 4);
+INSERT INTO version (name, value) VALUES ('revision', 5);
 
 


### PR DESCRIPTION
Otherwise we'll get conflicts with the upgrade scripts
