### PR TITLE
Limit the implicit join in transient search query.

### DIFF
--- a/tkp/database/utils/transients.py
+++ b/tkp/database/utils/transients.py
@@ -293,6 +293,7 @@ def transient_search(conn,
                             ,assocxtrsource ax
                         WHERE ax.runcat = %s
                           AND ex.image = %s
+                          AND ax.xtrsrc = ex.id
                     """
                     cursor.execute(query, (transient.runcatid, imageid))
                     trigger_xtrsrc = cursor.fetchall()[0][0]


### PR DESCRIPTION
Previously, we were doing the query on the cartesian product assocxtrsource
and extractedsource tables, which was returning crazy results (and causing
issue #3997). In fact, we're only interested on those rows where the
extractedsource and assocxtrsource tables are referring to the same source.

I think this should solve #3997, but please check my logic before merging.
