### PR TITLE
Update station sizes for calculation of RMS

### DIFF
--- a/tests/test_lofar/test_noise.py
+++ b/tests/test_lofar/test_noise.py
@@ -1,0 +1,41 @@
+import unittest
+if not  hasattr(unittest.TestCase, 'assertIsInstance'):
+    import unittest2 as unittest
+from tkp.lofar.noise import ANTENNAE_PER_TILE
+from tkp.lofar.noise import TILES_PER_CORE_STATION
+from tkp.lofar.noise import TILES_PER_REMOTE_STATION
+from tkp.lofar.noise import TILES_PER_INTL_STATION
+from tkp.lofar.noise import Aeff_dipole
+
+class TestHBAStationEffectiveArea(unittest.TestCase):
+    """
+    Values taken from table 2 of
+    http://www.astron.nl/radio-observatory/astronomers/lofar-imaging-capabilities-sensitivity/sensitivity-lofar-array/sensiti"
+    """
+    known_values = {
+        (120, 600, 1200, 2400),
+        (150, 512, 1024, 2048),
+        (180, 356, 711, 1422),
+        (200, 288, 576, 1152),
+        (210, 261, 522, 1045),
+        (240, 200, 400, 800)
+    }
+    def test_known_values(self):
+        for freq_eff, core, remote, intl in self.known_values:
+            freq_eff *= 1e6 # MHz to Hz
+
+            # The results quoted on the ASTRON web page are approximate -- we
+            # just need to get "near enough".
+            thresh = 3
+            self.assertLess(
+                abs(ANTENNAE_PER_TILE * TILES_PER_CORE_STATION * Aeff_dipole(freq_eff) - core),
+                thresh
+            )
+            self.assertLess(
+                abs(ANTENNAE_PER_TILE * TILES_PER_REMOTE_STATION * Aeff_dipole(freq_eff) - remote),
+                thresh
+            )
+            self.assertLess(
+                abs(ANTENNAE_PER_TILE * TILES_PER_INTL_STATION * Aeff_dipole(freq_eff) - intl),
+                thresh
+            )

--- a/tkp/lofar/noise.py
+++ b/tkp/lofar/noise.py
@@ -14,6 +14,11 @@ import tkp.lofar.antennaarrays
 
 logger = logging.getLogger(__name__)
 
+ANTENNAE_PER_TILE = 16
+TILES_PER_CORE_STATION = 24
+TILES_PER_REMOTE_STATION = 48
+TILES_PER_INTL_STATION = 96
+
 def noise_level(freq_eff, subbandwidth, tau_time, antenna_set, subbands=1, channels=64, Ncore=24, Nremote=16, Nintl=8):
     """ Returns the theoretical noise level given the supplied array antenna_set
 
@@ -33,10 +38,9 @@ def noise_level(freq_eff, subbandwidth, tau_time, antenna_set, subbands=1, chann
         ds_intl = tkp.lofar.antennaarrays.intl_dipole_distances[antenna_set]
         Aeff_intl = sum([tkp.lofar.noise.Aeff_dipole(freq_eff, x) for x in ds_intl])
     else:
-        # todo: check if this is correct. There are 16 antennae per tile. There are 24 tiles per core station
-        Aeff_core = 16 * 24 * tkp.lofar.noise.Aeff_dipole(freq_eff)
-        Aeff_remote = 16 * 24 * tkp.lofar.noise.Aeff_dipole(freq_eff)
-        Aeff_intl = 16 * 24 * tkp.lofar.noise.Aeff_dipole(freq_eff)
+        Aeff_core = ANTENNAE_PER_TILE * TILES_PER_CORE_STATON * tkp.lofar.noise.Aeff_dipole(freq_eff)
+        Aeff_remote = ANTENNAE_PER_TILE * TILES_PER_REMOTE_STATION * tkp.lofar.noise.Aeff_dipole(freq_eff)
+        Aeff_intl = ANTENNAE_PER_TILE * TILES_PER_INTL_STATION * tkp.lofar.noise.Aeff_dipole(freq_eff)
 
     # c = core, r = remote, i = international. So for example cc is core-core baseline
     Ssys_cc = system_sensitivity(freq_eff, Aeff_core)


### PR DESCRIPTION
This makes the calculated HBA effective areas match those given in Table 2 of
http://www.astron.nl/radio-observatory/astronomers/lofar-imaging-capabilities-sensitivity/sensitivity-lofar-array/sensiti.

Note that for the purposes of this file, "HBA core station" is equivalent to
an HBA _field_: in fact, there are two fields per station, but each field is
presented as a separate antenna in the MeasurementSet.
