### PR TITLE
Simplify calculations for wm_ra, wm_decl.

### DIFF
--- a/tkp/database/utils/associations.py
+++ b/tkp/database/utils/associations.py
@@ -315,17 +315,13 @@ INSERT INTO temprunningcatalog
                 ,image.band
                 ,image.stokes
                 ,rc0.datapoints + 1 AS datapoints
-                ,((datapoints * rc0.avg_wra + x0.ra /
-                  (x0.ra_err * x0.ra_err)) / (datapoints + 1))
+                ,(datapoints * rc0.avg_wra + x0.ra /(x0.ra_err * x0.ra_err) )
                  /
-                 ((datapoints * rc0.avg_weight_ra + 1 /
-                   (x0.ra_err * x0.ra_err)) / (datapoints + 1))
+                 (datapoints * rc0.avg_weight_ra + 1 / (x0.ra_err * x0.ra_err) )
                  AS wm_ra
-                ,((datapoints * rc0.avg_wdecl + x0.decl /
-                  (x0.decl_err * x0.decl_err)) / (datapoints + 1))
+                ,(datapoints * rc0.avg_wdecl + x0.decl /(x0.decl_err * x0.decl_err)) 
                  /
-                 ((datapoints * rc0.avg_weight_decl + 1 /
-                   (x0.decl_err * x0.decl_err)) / (datapoints + 1))
+                 (datapoints * rc0.avg_weight_decl + 1 /(x0.decl_err * x0.decl_err)) 
                  AS wm_decl
                 ,SQRT(1 / ((datapoints + 1) *
                   ((datapoints * rc0.avg_weight_ra +


### PR DESCRIPTION
No need to divide numerator and denominator by the same factor.

In fact, after some consideration, we can entirely do without the aggregate values avg_wra, avg_wdecl - because unlike the flux aggregates they are not required for a reduced chi-sq calculation.

However, since it's only a minor simplification / optimization, I shan't bother making the change until I've had a chance to check with Bart that I've not missed some detail / envisaged future usage.
