### PR TITLE
Minor docstring tweak to ImageData, to satisfy Sphinx.

### DIFF
--- a/tkp/sourcefinder/image.py
+++ b/tkp/sourcefinder/image.py
@@ -40,7 +40,7 @@ class ImageData(object):
           - data (2D numpy.ndarray): actual image data
           - wcs (utility.coordinates.wcs): world coordinate system
             specification
-          - bream (3-tuple): beam shape specification as
+          - beam (3-tuple): beam shape specification as
             (semimajor, semiminor, theta)
 
         """


### PR DESCRIPTION
I mainly did this to quieten Sphinx error messages, but it's a good example of
the arguments documentation style I've adopted elsewhere.

I suggest it as a standard for the TKP docs that balances clarity and
compactness - comments welcome.
