### PR TITLE
Quick fix for version value. It should be 11.

### DIFF
--- a/database/sql/tables/version.sql
+++ b/database/sql/tables/version.sql
@@ -4,5 +4,5 @@ CREATE TABLE version
   ,PRIMARY KEY(name)
 );
 
-INSERT INTO version (name, value) VALUES ('revision', 10);
+INSERT INTO version (name, value) VALUES ('revision', 11);
 


### PR DESCRIPTION
This was omitted in an db upgrade. When creating db from scratch, the version number should be set to 11.
