### PR TITLE
Catch failed fits and return None

### DIFF
--- a/tkp/sourcefinder/extract.py
+++ b/tkp/sourcefinder/extract.py
@@ -198,9 +198,14 @@ class Island(object):
 
     def fit(self, fixed=None):
         """Fit the position"""
-        measurement, gauss_residual = source_profile_and_errors(
-            self.data, self.threshold(), self.noise(), self.beam, fixed=fixed
-        )
+        try:
+            measurement, gauss_residual = source_profile_and_errors(
+                self.data, self.threshold(), self.noise(), self.beam, fixed=fixed
+            )
+        except ValueError:
+            # Fitting failed
+            logger.error("Moments & Gaussian fitting failed at %s" % (str(self.position)))
+            return None
         measurement["xbar"] += self.position[0] + 1 # address + offset  = address but not address + address 
         measurement["ybar"] += self.position[1] + 1 # because addresses start at 0
         measurement.sig = self.sig()


### PR DESCRIPTION
Prevents the sourcefinder raising a ValueError, and hence the pipeline failure seen at https://support.astron.nl/lofar_issuetracker/issues/4238.
