### PR TITLE
Make quality checks telescope dependent.

### DIFF
--- a/tkp/distribute/celery/__init__.py
+++ b/tkp/distribute/celery/__init__.py
@@ -67,7 +67,6 @@ def run(job_name, local=False):
     dump_job_config_to_logdir(pipe_config, job_config)
 
     p_parset = parset.load_section(job_config, 'persistence')
-    q_lofar_parset = parset.load_section(job_config, 'quality_lofar')
     se_parset = parset.load_section(job_config, 'source_extraction')
     nd_parset = parset.load_section(job_config, 'null_detections')
     tr_parset = parset.load_section(job_config, 'transient_search')
@@ -91,7 +90,7 @@ def run(job_name, local=False):
 
     # quality_check
     urls = [img.url for img in images]
-    arguments = [q_lofar_parset]
+    arguments = [job_config]
     rejecteds = runner(tasks.quality_reject_check, urls, arguments, local)
 
     good_images = []

--- a/tkp/distribute/celery/tasks.py
+++ b/tkp/distribute/celery/tasks.py
@@ -30,8 +30,8 @@ def persistence_node_step(images, p_parset):
     return tkp.steps.persistence.node_steps(images, p_parset)
 
 @celery.task
-def quality_reject_check(url, q_parset):
-    return tkp.steps.quality.reject_check(url, q_parset)
+def quality_reject_check(url, job_config):
+    return tkp.steps.quality.reject_check(url, job_config)
 
 @celery.task
 def extract_sources(url, se_parset):


### PR DESCRIPTION
Passing the whole job config feels a bit kludgey, but I don't think it's a major
cost really. If we really wanted to we could do something smart like pick out
all sections with names beginning 'quality_' but it's probably more
trouble than it's worth.
