### PR TITLE
PySE forced fits

### DIFF
--- a/tests/test_bin/test_pyse.py
+++ b/tests/test_bin/test_pyse.py
@@ -40,7 +40,8 @@ options = AttributeDict({
     'csv': True,
     'force_beam': True,
     'alpha': .1,
-    'detection_image': False
+    'detection_image': False,
+    'mode': 'threshold'
 })
 
 
@@ -148,8 +149,8 @@ class TestPyse(unittest.TestCase):
         tkp.bin.pyse.run_sourcefinder([self.filename], options)
         self.assertEqual(tkp.bin.pyse.get_detection_labels.callcount, 0)
 
-        # But if we set options.detection_image to True, we should
-        options.detection_image = True
+        # But if we set options.mode="detimage", we should
+        options.mode = "detimage"
         tkp.bin.pyse.run_sourcefinder([self.filename], options)
         self.assertEqual(tkp.bin.pyse.get_detection_labels.callcount, 1)
 

--- a/tkp/bin/pyse.py
+++ b/tkp/bin/pyse.py
@@ -35,12 +35,11 @@ from tkp.accessors import writefits as tkp_writefits
 from tkp.sourcefinder.utils import generate_result_maps
 from tkp.management import parse_monitoringlist_positions
 
-def regions(sourcelist, type_labels=False):
+def regions(sourcelist):
     """
     Return a string containing a DS9-compatible region file describing all the
     sources in sourcelist.
     """
-    labels = {'blind':'b', 'forced':'f'}
     output = StringIO()
     print >>output, "# Region file format: DS9 version 4.1"
     print >>output, "global color=green dashlist=8 3 width=1 font=\"helvetica 10 normal\" select=1 highlite=1 dash=0 fixed=0 edit=1 move=1 delete=1 include=1 source=1"
@@ -53,12 +52,6 @@ def regions(sourcelist, type_labels=False):
             source.smaj.value*2,
             source.smin.value*2,
             math.degrees(source.theta)+90
-        )
-        if type_labels:
-            print >> output, "text %f %f {%s}" % (
-            source.x.value + 1.0,
-            source.y.value + 1.0,
-            labels[source.type]
         )
     return output.getvalue()
 
@@ -86,10 +79,9 @@ def csv(sourcelist):
     Return a string containing a csv from the extracted sources.
     """
     output = StringIO()
-    print >> output, "type, ra, ra_err, dec, dec_err, smaj, smaj_err, smin, smin_err, pa, pa_err, int_flux, int_flux_err, pk_flux, pk_flux_err"
+    print >> output, "ra, ra_err, dec, dec_err, smaj, smaj_err, smin, smin_err, pa, pa_err, int_flux, int_flux_err, pk_flux, pk_flux_err"
     for source in sourcelist:
         print >> output, "%s, %f, %f, %f, %f, %f, %f, %f, %f, %f, %f, %f, %f, %f, %f" % (
-            source.type,
             source.ra,
             source.ra.error,
             source.dec,
@@ -115,7 +107,6 @@ def summary(filename, sourcelist):
     output = StringIO()
     print >>output, "** %s **\n" % (filename)
     for source in sourcelist:
-        print >> output, "Type: %s" % (source.type)
         print >>output, "RA: %s, dec: %s" % (str(source.ra), str(source.dec))
         print >>output, "Error radius (arcsec): %s" % (str(source.error_radius))
         print >>output, "Semi-major axis (arcsec): %s" % (str(source.smaj_asec))
@@ -137,7 +128,6 @@ def handle_args(args=None):
     parser.add_option("--detection", default=10, type="float", help="Detection threshold")
     parser.add_option("--analysis", default=3, type="float", help="Analysis threshold")
     parser.add_option("--regions", action="store_true", help="Generate DS9 region file(s)")
-    parser.add_option("--labels", action="store_true", help="Label extraction type in DS9 region file(s) (forced/blind)")
     parser.add_option("--residuals", action="store_true", help="Generate residual maps")
     parser.add_option("--islands", action="store_true", help="Generate island maps")
     parser.add_option("--deblend", action="store_true", help="Deblend composite sources")
@@ -154,18 +144,52 @@ def handle_args(args=None):
     parser.add_option("--sigmap", action="store_true", help="Generate significance map")
     parser.add_option("--force-beam", action="store_true", help="Force fit axis lengths to beam size")
     parser.add_option("--detection-image", type="string", help="Find islands on different image")
-    m_help = 'Specify a list of RA,Dec co-ordinate positions to force-fit ' \
-             '(decimal degrees, JSON format e.g. "[[144.2,33.3],[146.1,34.1]]" )'
-    parser.add_option('--monitor-coords', help=m_help, default=None)
-    parser.add_option('--monitor-list',
-                      help='Specify a file containing a list of monitor-coords',
-                      default=None)
-    box_help = "Specify forced fitting positional freedom / error-box size, as a multiple of beam width."
-    parser.add_option('--ffbox-in-beampix', type='float', default=3.,help=box_help)
+    m_help = "Specify a list of RA,Dec co-ordinate positions to force-fit " \
+        '(decimal degrees, JSON format e.g. "[[144.2,33.3],[146.1,34.1]]" )'
+    parser.add_option('--fixed', help=m_help, default=None)
+    parser.add_option('--fixed-list',
+        help="Specify a file containing a list of positions to force-fit", default=None
+    )
+    box_help = "Specify forced fitting positional freedom / error-box size, " \
+        "as a multiple of beam width."
+    parser.add_option('--ffbox-in-beampix', type='float', default=3., help=box_help)
     options, files = parser.parse_args(args=args)
-    # Overwrite 'monitor_coords' with a parsed list of coords
+
+    # Overwrite 'fixed_coords' with a parsed list of coords
     # collated from both command line and file.
-    options.monitor_coords = parse_monitoringlist_positions(options)
+    options.fixed_coords = parse_monitoringlist_positions(
+        options, str_name="fixed", list_name="fixed_list"
+    )
+    # Quick & dirty check that the position list looks plausible
+    if options.fixed_coords:
+        mlist = numpy.array(options.fixed_coords)
+        if not (len(mlist.shape) == 2 and mlist.shape[1] == 2):
+            parser.error("Positions for forced-fitting must be [RA,dec] pairs")
+
+    # We have four potential modes, of which we choose only one to run:
+    #
+    # 1. Blind sourcefinding
+    #  1.1 Thresholding, no detection image (no extra cmd line options)
+    #  1.2 Thresholding, detection image (--detection-image)
+    #  1.3 FDR (--fdr)
+    #
+    # 2. Fit to fixed points (--fixed-coords and/or --fixed-list)
+
+    if options.fixed_coords:
+        if options.fdr:
+            parser.error("--fdr not supported with fixed positions")
+        elif options.detection_image:
+            parser.error("--detection-image not supported with fixed positions")
+        options.mode = "fixed" # mode 2 above
+    elif options.fdr:
+        if options.detection_image:
+            parser.error("--detection-image not supported with --fdr")
+        options.mode = "fdr" # mode 1.3 above
+    elif options.detection_image:
+        options.mode = "detimage" # mode 1.2 above
+    else:
+        options.mode = "threshold" # mode 1.1 above
+
     return options, files
 
 def writefits(filename, data, header={}):
@@ -229,49 +253,37 @@ def run_sourcefinder(files, options):
     beam = get_beam(options.bmaj, options.bmin, options.bpa)
     configuration = get_sourcefinder_configuration(options)
 
-    if options.detection_image and options.fdr:
-        bailout("--detection-image not suppored with --fdr")
-
-    if options.detection_image:
+    if options.mode == "detimage":
         labels, labelled_data = get_detection_labels(
             options.detection_image, options.detection, options.analysis, beam, configuration
         )
     else:
         labels, labelled_data = [], None
+
     for counter, filename in enumerate(files):
-        imagename = os.path.splitext(os.path.basename(filename))[0]
         print "Processing %s (file %d of %d)." % (filename, counter+1, len(files))
+        imagename = os.path.splitext(os.path.basename(filename))[0]
         ff = open_accessor(filename, beam=beam, plane=0)
         imagedata = sourcefinder_image_from_accessor(ff, **configuration)
-        if options.fdr:
-            print "Using False Detection Rate algorithm with alpha = %f" % (options.alpha,)
-            sr = imagedata.fd_extract(options.alpha)
-        else:
-            if labelled_data is None:
-                print "Thresholding with det = %f sigma, analysis = %f sigma" % (options.detection, options.analysis)
-            sr = imagedata.extract(options.detection, options.analysis, labelled_data=labelled_data, labels=labels)
 
-        if options.monitor_coords:
-            ffbox_in_pix = options.ffbox_in_beampix * max(imagedata.beam[0],
-                                                          imagedata.beam[1])
-            forced_fits = imagedata.fit_fixed_positions(options.monitor_coords, 
-                                                        boxsize=ffbox_in_pix)
+        if options.mode == "fixed":
+            sr = imagedata.fit_fixed_positions(options.fixed_coords,
+                options.ffbox_in_beampix * max(imagedata.beam[0:2])
+            )
+
         else:
-            forced_fits = None
-        # #Kludge a distinguishing flag on here,
-        # to allow for passing a single list around:
-        # (see https://support.astron.nl/lofar_issuetracker/issues/4964)
-        for s in sr:
-            s.type = 'blind'
-        if forced_fits:
-            for s in forced_fits:
-                s.type = 'forced'
-            sr.extend(forced_fits)
+            if options.mode == "fdr":
+                print "Using False Detection Rate algorithm with alpha = %f" % (options.alpha,)
+                sr = imagedata.fd_extract(options.alpha)
+            else:
+                if labelled_data is None:
+                    print "Thresholding with det = %f sigma, analysis = %f sigma" % (options.detection, options.analysis)
+                sr = imagedata.extract(options.detection, options.analysis, labelled_data=labelled_data, labels=labels)
 
         if options.regions:
             regionfile = imagename + ".reg"
             regionfile = open(regionfile, 'w')
-            regionfile.write(regions(sr, options.labels))
+            regionfile.write(regions(sr))
             regionfile.close()
         if options.residuals or options.islands:
             gaussian_map, residual_map = generate_result_maps(imagedata.data, sr)

--- a/tkp/management.py
+++ b/tkp/management.py
@@ -172,7 +172,7 @@ def copy_template(job_or_project, name, target=None, **options):
                                   "problem.\n" % new_path)
     return top_dir
 
-def parse_monitoringlist_positions(args):
+def parse_monitoringlist_positions(args, str_name="monitor_coords", list_name="monitor_list"):
     """Loads a list of monitoringlist (RA,Dec) tuples from cmd line args object.
 
     Processes the flags "--monitor-coords" and "--monitor-list"
@@ -180,21 +180,21 @@ def parse_monitoringlist_positions(args):
     those should be matched against whatever uses the resulting values...
     """
     monitor_coords=[]
-    if args.monitor_coords:
+    if hasattr(args, str_name) and getattr(args, str_name):
         try:
-            monitor_coords.extend(json.loads(args.monitor_coords))
+            monitor_coords.extend(json.loads(getattr(args, str_name)))
         except ValueError:
             logging.error("Could not parse monitor-coords from command line:"
-                         "string passed was:\n%s", args.monitor_coords
+                         "string passed was:\n%s" % (getattr(args, str_name),)
                          )
             raise
-    if args.monitor_list:
+    if hasattr(args, list_name) and getattr(args, list_name):
         try:
-            mon_list = json.load(open(args.monitor_list))
+            mon_list = json.load(open(getattr(args, list_name)))
             monitor_coords.extend(mon_list)
         except ValueError:
             logging.error("Could not parse monitor-coords from file: "
-                              +args.monitor_list)
+                              + getattr(args, list_name))
             raise
     return monitor_coords
 


### PR DESCRIPTION
This reworks Tim's forced-fit addition to Pyse such that:
- Only run one of:
  - forced fits;
  - blind thresholding;
  - thresholding with detection image;
  - FDR
    per run.
- Don't label detection type (There Can Be Only One given the above).
- Saner checking for conflicting options.
- Use "--fixed" and "--fixed-list" for fixed positions.
- Make unit tests pass.
