### PR TITLE
Adjust ref dec away from NCP before saving FITS

### DIFF
--- a/tests/test_steps/test_persistence.py
+++ b/tests/test_steps/test_persistence.py
@@ -65,6 +65,10 @@ class TestFixReferenceDec(unittest.TestCase):
         # Default unit is degrees.
         self._test_for_reference_dec(90.0)
 
+    def test_dec_minus90(self):
+        # Default unit is degrees.
+        self._test_for_reference_dec(-90.0)
+
     def test_dec_90_deg(self):
         self._test_for_reference_dec(90.0, "deg")
 
@@ -79,4 +83,4 @@ class TestFixReferenceDec(unittest.TestCase):
                 h.header.update("CUNIT2", unit)
             h.writeto(temp_fits.name)
             tkp.steps.persistence.fix_reference_dec(temp_fits.name)
-            self.assertLess(pyfits.getheader(temp_fits.name)['CRVAL2'], refdec)
+            self.assertLess(abs(pyfits.getheader(temp_fits.name)['CRVAL2']), abs(refdec))

--- a/tkp/steps/persistence.py
+++ b/tkp/steps/persistence.py
@@ -35,7 +35,7 @@ def fix_reference_dec(imagename):
             critical_value = math.pi/2 # radians
 
         ref_dec = ff[0].header['CRVAL2']
-        if (critical_value - ref_dec) < TINY:
+        if (critical_value - abs(ref_dec)) < TINY:
             ff[0].header['CRVAL2'] = ref_dec * (1 - TINY)
             ff.flush()
 


### PR DESCRIPTION
This should address the "flipped image" problem in Banana: see #4599.
