### PR TITLE
Rationlize pipeline.cfg.

### DIFF
--- a/tkp/conf/project_template/pipeline.cfg
+++ b/tkp/conf/project_template/pipeline.cfg
@@ -1,15 +1,9 @@
 [DEFAULT]
 runtime_directory = %(cwd)s
-default_job_directory = %(runtime_directory)s/%(job_name)s
-
-
-[layout]
 job_directory = %(runtime_directory)s/%(job_name)s
-working_directory = %(job_directory)s/working_dir
-
 
 [logging]
-log_file = %(default_job_directory)s/logs/%(start_time)s/pipeline.log
+log_file = %(job_directory)s/logs/%(start_time)s/pipeline.log
 debug = False
 
 [database]

--- a/tkp/distribute/celery/__init__.py
+++ b/tkp/distribute/celery/__init__.py
@@ -94,7 +94,7 @@ def run(job_name, local=False):
                              job_name)
 
     db_config = database_config(pipe_config, apply=True)
-    job_dir = pipe_config.get('layout', 'job_directory')
+    job_dir = pipe_config.get('DEFAULT', 'job_directory')
     debug = pipe_config.getboolean('logging', 'debug')
     log_dir = os.path.dirname(pipe_config.get('logging', 'log_file'))
     setup_file_logging(log_dir, debug)

--- a/tkp/distribute/common.py
+++ b/tkp/distribute/common.py
@@ -12,7 +12,7 @@ def load_job_config(pipe_config):
     combined ConfigParser object representing the 'job settings', i.e.
     the parameters relating to this particular data reduction run.
     """
-    job_directory = pipe_config.get('layout', 'job_directory')
+    job_directory = pipe_config.get('DEFAULT', 'job_directory')
     job_config = ConfigParser.SafeConfigParser()
     job_config.read(os.path.join(job_directory, 'job_params.cfg'))
     return job_config


### PR DESCRIPTION
Remove unused working_directory. Don't need both job_directory and
default_job_directory.
