### PR TITLE
Properly honour log_file configuration

### DIFF
--- a/tkp/distribute/celery/__init__.py
+++ b/tkp/distribute/celery/__init__.py
@@ -96,8 +96,8 @@ def run(job_name, local=False):
     db_config = database_config(pipe_config, apply=True)
     job_dir = pipe_config.get('DEFAULT', 'job_directory')
     debug = pipe_config.getboolean('logging', 'debug')
-    log_dir = os.path.dirname(pipe_config.get('logging', 'log_file'))
-    setup_file_logging(log_dir, debug)
+    log_file = pipe_config.get('logging', 'log_file')
+    setup_file_logging(log_file, debug)
 
     if not os.access(job_dir, os.X_OK):
         msg = "can't access job folder %s" % job_dir
@@ -133,7 +133,7 @@ def run(job_name, local=False):
 
     logger.info("dataset %s contains %s images" % (job_name, len(all_images)))
 
-    dump_job_config_to_logdir(log_dir, job_config)
+    dump_job_config_to_logdir(os.path.dirname(log_file), job_config)
 
     p_parset = parse_to_dict(job_config, 'persistence')
     se_parset = parse_to_dict(job_config, 'source_extraction')

--- a/tkp/distribute/common.py
+++ b/tkp/distribute/common.py
@@ -25,21 +25,21 @@ def dump_job_config_to_logdir(log_dir, job_config):
         job_config.write(f)
 
 
-def setup_file_logging(log_dir, debug=False):
+def setup_file_logging(log_file, debug=False):
     """
-    sets up a catch all logging handler which writes to a file in `log_dir`.
+    sets up a catch all logging handler which writes to `log_file`.
 
-    :param log_dir: where to store the log file
+    :param log_file: log file to write
     :param debug: do we want debug level logging?
     """
-    if not os.path.isdir(log_dir):
-        os.makedirs(log_dir)
+    if not os.path.isdir(os.path.dirname(log_file)):
+        os.makedirs(os.path.dirname(log_file))
     global_logger = logging.getLogger()
-    hdlr = logging.FileHandler(os.path.join(log_dir, 'output.log'))
+    hdlr = logging.FileHandler(log_file)
     global_logger.addHandler(hdlr)
     formatter = logging.Formatter('%(asctime)s %(levelname)s %(name)s: %(message)s')
     hdlr.setFormatter(formatter)
-    logger.info("logging to %s" % log_dir)
+    logger.info("logging to %s" % log_file)
     if debug:
         global_logger.setLevel(logging.DEBUG)
     else:


### PR DESCRIPTION
We were stripping off the filename and always writing a file named "output.log" regardless of configuration. Which was sad.
