### PR TITLE
Use math.isnan to test for NaN.

### DIFF
--- a/tests/test_utility/test_substitute_nan.py
+++ b/tests/test_utility/test_substitute_nan.py
@@ -1,0 +1,24 @@
+import unittest2 as unittest
+from tkp.utility import substitute_nan
+
+class SubstituteNanTestCase(unittest.TestCase):
+    def test_not_nan(self):
+        """
+        Non-NaN returned unchanged.
+        """
+        value = 1
+        self.assertEqual(substitute_nan(value), value)
+
+    def test_nan(self):
+        """
+        NaN substituted to 0.
+        """
+        value = float("nan")
+        self.assertEqual(substitute_nan(value), 0.0)
+
+    def test_non_default_subst(self):
+        """
+        NaN substitute to non default.
+        """
+        value = float("nan")
+        self.assertEqual(substitute_nan(value, 99), 99)

--- a/tkp/db/transients.py
+++ b/tkp/db/transients.py
@@ -10,6 +10,7 @@ from scipy.stats import chisqprob
 
 import tkp.db
 from tkp.db.generic import get_db_rows_as_dicts
+from tkp.utility import substitute_nan
 
 
 logger = logging.getLogger(__name__)
@@ -231,10 +232,10 @@ def multi_epoch_transient_search(image_id,
     for entry in updated_variability_indices:
         probability_not_flat = 1 - chisqprob(entry['eta_int'] * (entry['f_datapoints'] - 1),
                                              (entry['f_datapoints'] - 1))
-        if probability_not_flat == probability_not_flat:
-            entry['siglevel'] = float(probability_not_flat) #Monetdb doesn't like numpy.float64
-        else: #prob = NaN
-            entry['siglevel'] = 0.0
+
+        # If the above is not NaN, we use it; otherwise, 0.
+        # The call to float() converts to a type suits the DB-API.
+        entry['siglevel'] = float(substitute_nan(probability_not_flat))
 
     old_transients = [entry for entry in updated_variability_indices
                             if not entry['new_transient']]

--- a/tkp/utility/__init__.py
+++ b/tkp/utility/__init__.py
@@ -1,5 +1,16 @@
+import math
+
 def nice_format(f):
     if f > 9999 or f < 0.01:
         return "%.2e" % f
     else:
         return "%.2f" % f
+
+def substitute_nan(value, substitute=0.0):
+    """
+    If value is not NaN, return value. Otherwise, return substitute.
+    """
+    if math.isnan(value):
+        return substitute
+    else:
+        return value


### PR DESCRIPTION
This is certainly more idiomatic than testing for value != value, and might be
more correct: that test can be optimized out by badly behaving compilers, and
the internet seems unsure as to whether it's safe in Python
(http://stackoverflow.com/questions/944700/how-to-check-for-nan-in-python#comment2016153_944734).
