### PR TITLE
DB config

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,11 +25,13 @@ class DatabaseConfigTestCase(unittest.TestCase):
         os.environ = self.old_environment
 
     def test_unconfigured(self):
-        self.assertRaises(Exception, database_config)
+        # Should *not* raise.
+        database_config()
 
     def test_invalid_dbengine(self):
+        # Should *not* raise; database_config does not sanity check.
         os.environ["TKP_DBENGINE"] = DUMMY_VALUE
-        self.assertRaises(Exception, database_config)
+        database_config()
 
     def test_defaults_postgresql(self):
         # Demonstrate that we get the expected default values

--- a/tkp/config.py
+++ b/tkp/config.py
@@ -72,9 +72,6 @@ def database_config(pipe_config=None, apply=False):
     if kwargs['user'] and not kwargs['password']:
         kwargs['password'] = kwargs['user']
 
-    if not kwargs['engine'] in ("postgresql", "monetdb"):
-        raise Exception("Invalid database engine")
-
     if not kwargs['port']:
         if kwargs['engine'] == "monetdb":
             kwargs['port'] = 50000


### PR DESCRIPTION
`database_config()` does not sanity check the database engine.

Hence, it doesn't raise before control passes back to `management.py`.

`Database.connect()` still does the sanity checking, so we don't lose in terms of correctness.
