### PR TITLE
Do not alter WCS on saving to MongoDB

### DIFF
--- a/tests/test_steps/test_persistence.py
+++ b/tests/test_steps/test_persistence.py
@@ -59,28 +59,3 @@ class TestMongoDb(unittest.TestCase):
     def test_image_to_mongodb(self):
         self.assertTrue(tkp.steps.persistence.image_to_mongodb(self.images[0],
                                                     hostname, port, database))
-
-class TestFixReferenceDec(unittest.TestCase):
-    def test_dec_90(self):
-        # Default unit is degrees.
-        self._test_for_reference_dec(90.0)
-
-    def test_dec_minus90(self):
-        # Default unit is degrees.
-        self._test_for_reference_dec(-90.0)
-
-    def test_dec_90_deg(self):
-        self._test_for_reference_dec(90.0, "deg")
-
-    def test_dec_pi_by_2_rad(self):
-        self._test_for_reference_dec(math.pi/2, "rad")
-
-    def _test_for_reference_dec(self, refdec, unit=None):
-        with tempfile.NamedTemporaryFile() as temp_fits:
-            h = pyfits.PrimaryHDU()
-            h.header.update("CRVAL2", refdec)
-            if unit:
-                h.header.update("CUNIT2", unit)
-            h.writeto(temp_fits.name)
-            tkp.steps.persistence.fix_reference_dec(temp_fits.name)
-            self.assertLess(abs(pyfits.getheader(temp_fits.name)['CRVAL2']), abs(refdec))

--- a/tests/test_utility/test_fits.py
+++ b/tests/test_utility/test_fits.py
@@ -1,0 +1,30 @@
+import unittest
+import pyfits
+import math
+import tempfile
+from tkp.utility.fits import fix_reference_dec
+
+class TestFixReferenceDec(unittest.TestCase):
+    def test_dec_90(self):
+        # Default unit is degrees.
+        self._test_for_reference_dec(90.0)
+
+    def test_dec_minus90(self):
+        # Default unit is degrees.
+        self._test_for_reference_dec(-90.0)
+
+    def test_dec_90_deg(self):
+        self._test_for_reference_dec(90.0, "deg")
+
+    def test_dec_pi_by_2_rad(self):
+        self._test_for_reference_dec(math.pi/2, "rad")
+
+    def _test_for_reference_dec(self, refdec, unit=None):
+        with tempfile.NamedTemporaryFile() as temp_fits:
+            h = pyfits.PrimaryHDU()
+            h.header.update("CRVAL2", refdec)
+            if unit:
+                h.header.update("CUNIT2", unit)
+            h.writeto(temp_fits.name)
+            fix_reference_dec(temp_fits.name)
+            self.assertLess(abs(pyfits.getheader(temp_fits.name)['CRVAL2']), abs(refdec))

--- a/tkp/steps/persistence.py
+++ b/tkp/steps/persistence.py
@@ -1,11 +1,9 @@
 import os
-import math
 import logging
 import warnings
 from tempfile import NamedTemporaryFile
 
 from pyrap.images import image as pyrap_image
-import pyfits
 
 import tkp.accessors
 from tkp.db.database import Database
@@ -13,31 +11,6 @@ from tkp.db.orm import DataSet, Image
 
 
 logger = logging.getLogger(__name__)
-
-def fix_reference_dec(imagename):
-    """
-    If the FITS file specified has a reference dec of 90 (or pi/2), make it
-    infinitesimally less. This works around problems with ill-defined
-    coordinate systems at the north celestial pole.
-    """
-    # TINY is an arbitrary constant which we regard as "far enough" away from
-    # dec 90 (or pi/2). In theory, we ought to be able to us
-    # sys.float_info.epsilon, but pyfits seems to round this when writing it
-    # to a FITS file so that isn't quite generous enough.
-    TINY = 1e-10
-    with pyfits.open(imagename, mode='update') as ff:
-        # The FITS standard (version 3.0, July 2008) tells us "For angular
-        # measurements given as floating-point values [...] the units should
-        # be degrees". We therefore use that as a default, but handle radians
-        # too, just to be on the safe side.
-        critical_value = 90.0 # degrees
-        if "CUNIT2" in ff[0].header and ff[0].header["CUNIT2"] == "rad":
-            critical_value = math.pi/2 # radians
-
-        ref_dec = ff[0].header['CRVAL2']
-        if (critical_value - abs(ref_dec)) < TINY:
-            ff[0].header['CRVAL2'] = ref_dec * (1 - TINY)
-            ff.flush()
 
 def image_to_mongodb(filename, hostname, port, db):
     """Copy a file into mongodb"""
@@ -64,7 +37,6 @@ def image_to_mongodb(filename, hostname, port, db):
             temp_fits_file = NamedTemporaryFile()
             i = pyrap_image(filename)
             i.tofits(temp_fits_file.name)
-            fix_reference_dec(temp_fits_file.name)
             new_file = gfs.new_file(filename=filename)
             with open(temp_fits_file.name, "r") as f:
                 new_file.write(f)


### PR DESCRIPTION
This hasn't helped problems with sources being displayed incorrectly in
Banana: we will fix it in the Banana codebase instead.

I'm retaining the code that does the munging because I imagine it could well
be useful in future.
