### PR TITLE
Remove all mention of unittest2

### DIFF
--- a/documentation/devref/developing.rst
+++ b/documentation/devref/developing.rst
@@ -176,16 +176,7 @@ I suggest to follow at least one simple rule:
 Unit tests
 ----------
 
-The unit tests use the :mod:`unittest2` module. For Python 2.7, this
-is the built-in :mod:`unittest` module, but for earlier versions, the
-module needs to be installed separately. The unit tests have the
-following check at the import level for this::
-
-    import unittest
-    try:
-        unittest.TestCase.assertIsInstance
-    except AttributeError:
-        import unittest2 as unittest
+The unit tests use the Python 2.7's :mod:`unittest` module.
 
 Running the unit tests
 ----------------------

--- a/tests/test_accessors/test_casatable.py
+++ b/tests/test_accessors/test_casatable.py
@@ -1,6 +1,6 @@
 import os
 
-import unittest2 as unittest
+import unittest
 
 import tkp.accessors as accessors
 from tkp.testutil.data import DATAPATH

--- a/tests/test_accessors/test_detection.py
+++ b/tests/test_accessors/test_detection.py
@@ -1,6 +1,6 @@
 import os
 
-import unittest2 as unittest
+import unittest
 
 
 from tkp.accessors.detection import isfits, islofarhdf5, detect, iscasa

--- a/tests/test_accessors/test_fits.py
+++ b/tests/test_accessors/test_fits.py
@@ -4,7 +4,7 @@ Tests for simulated LOFAR datasets.
 
 import os
 
-import unittest2 as unittest
+import unittest
 
 from tkp.testutil.data import DATAPATH
 from tkp import accessors

--- a/tests/test_accessors/test_kat7casatable.py
+++ b/tests/test_accessors/test_kat7casatable.py
@@ -1,6 +1,6 @@
 import os
 
-import unittest2 as unittest
+import unittest
 
 from tkp import accessors
 from tkp.accessors.kat7casaimage import Kat7CasaImage

--- a/tests/test_accessors/test_lofarcasatable.py
+++ b/tests/test_accessors/test_lofarcasatable.py
@@ -1,6 +1,6 @@
 import os
 
-import unittest2 as unittest
+import unittest
 
 from tkp import accessors
 from tkp.accessors.lofaraccessor import LofarAccessor

--- a/tests/test_bin/test_pyse.py
+++ b/tests/test_bin/test_pyse.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 import shutil
 
-import unittest2 as unittest
+import unittest
 
 import tkp.bin.pyse
 from tkp.accessors import FitsImage

--- a/tests/test_classification/test_feature_extraction.py
+++ b/tests/test_classification/test_feature_extraction.py
@@ -16,7 +16,7 @@ comparison is more approritate.
 """
 import numpy
 
-import unittest2 as unittest
+import unittest
 
 from datetime import datetime
 from datetime import timedelta

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest
 import os
 import getpass
 import datetime

--- a/tests/test_database/test_algorithms.py
+++ b/tests/test_database/test_algorithms.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest
 from tkp.db.orm import DataSet, Image
 import tkp.db
 from tkp.testutil.decorators import requires_database

--- a/tests/test_database/test_associations.py
+++ b/tests/test_database/test_associations.py
@@ -2,7 +2,7 @@ import math
 import logging
 from io import BytesIO
 
-import unittest2 as unittest
+import unittest
 
 import tkp.db
 import tkp.db.general as dbgen

--- a/tests/test_database/test_band.py
+++ b/tests/test_database/test_band.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest
 
 import datetime
 from tkp.testutil.decorators import requires_database

--- a/tests/test_database/test_connector.py
+++ b/tests/test_database/test_connector.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest
 from exceptions import StandardError
 from tkp.testutil.decorators import requires_database
 import tkp.db

--- a/tests/test_database/test_consistency.py
+++ b/tests/test_database/test_consistency.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest
 import tkp.db.consistency as db_consistency
 import tkp.db
 from tkp.testutil import Mock

--- a/tests/test_database/test_dump.py
+++ b/tests/test_database/test_dump.py
@@ -1,5 +1,5 @@
 import os
-import unittest2 as unittest
+import unittest
 from tempfile import NamedTemporaryFile
 from tkp.config import get_database_config
 from tkp.db.dump import dump_db, dump_monetdb, dump_pg

--- a/tests/test_database/test_fluxes.py
+++ b/tests/test_database/test_fluxes.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest
 import tkp.db
 import tkp.db.general as dbgen
 from tkp.db.generic import  get_db_rows_as_dicts, columns_from_table

--- a/tests/test_database/test_general.py
+++ b/tests/test_database/test_general.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest
 
 import time
 from tkp.db.orm import DataSet

--- a/tests/test_database/test_lightcurve.py
+++ b/tests/test_database/test_lightcurve.py
@@ -1,7 +1,7 @@
 from operator import attrgetter, itemgetter
 from collections import namedtuple
 
-import unittest2 as unittest
+import unittest
 
 import datetime
 from tkp.testutil.decorators import requires_database

--- a/tests/test_database/test_lightsurface.py
+++ b/tests/test_database/test_lightsurface.py
@@ -1,6 +1,6 @@
 from operator import attrgetter
 
-import unittest2 as unittest
+import unittest
 
 import datetime
 from tkp.testutil.decorators import requires_database

--- a/tests/test_database/test_monitoringlist.py
+++ b/tests/test_database/test_monitoringlist.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest
 import tkp.db
 from tkp.db import monitoringlist
 from tkp.testutil import db_subs

--- a/tests/test_database/test_nulldetections.py
+++ b/tests/test_database/test_nulldetections.py
@@ -1,7 +1,7 @@
 import datetime
 import itertools
 
-import unittest2 as unittest
+import unittest
 
 import tkp.db
 from tkp.db import associations as dbass

--- a/tests/test_database/test_orm.py
+++ b/tests/test_database/test_orm.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest
 
 import datetime
 from tkp.testutil.decorators import requires_database

--- a/tests/test_database/test_reject.py
+++ b/tests/test_database/test_reject.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest
 import tkp.db
 from tkp.testutil import db_subs
 from tkp.testutil.decorators import requires_database

--- a/tests/test_database/test_skyregion.py
+++ b/tests/test_database/test_skyregion.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest
 import tkp.db
 from tkp.db import monitoringlist as dbmon
 from tkp.testutil import db_subs

--- a/tests/test_database/test_subroutines.py
+++ b/tests/test_database/test_subroutines.py
@@ -1,6 +1,6 @@
 import math
 
-import unittest2 as unittest
+import unittest
 
 import tkp.db
 from tkp.testutil.decorators import requires_database

--- a/tests/test_database/test_transients.py
+++ b/tests/test_database/test_transients.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest
 import tkp.db
 from tkp.db.transients import multi_epoch_transient_search
 from tkp.db.transients import _insert_transients

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,6 +1,6 @@
 import os
 
-import unittest2 as unittest
+import unittest
 from tkp.testutil.decorators import requires_database, requires_data, duration
 from tkp.testutil.data import DATAPATH
 

--- a/tests/test_lofar/test_noise.py
+++ b/tests/test_lofar/test_noise.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest
 from tkp.lofar.noise import ANTENNAE_PER_TILE
 from tkp.lofar.noise import TILES_PER_CORE_STATION
 from tkp.lofar.noise import TILES_PER_REMOTE_STATION

--- a/tests/test_quality/test_brightsource.py
+++ b/tests/test_quality/test_brightsource.py
@@ -2,7 +2,7 @@ import os
 from math import degrees
 from pyrap.measures import measures
 
-import unittest2 as unittest
+import unittest
 
 from tkp.testutil.decorators import requires_data
 import tkp.quality.brightsource

--- a/tests/test_quality/test_reject.py
+++ b/tests/test_quality/test_reject.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest
 import tkp.quality
 import tkp.db
 import tkp.db.quality

--- a/tests/test_quality/test_restoringbeam.py
+++ b/tests/test_quality/test_restoringbeam.py
@@ -1,6 +1,6 @@
 import os
 
-import unittest2 as unittest
+import unittest
 from tkp.quality.restoringbeam import beam_invalid
 
 from tkp.testutil.decorators import requires_data

--- a/tests/test_quality/test_rms.py
+++ b/tests/test_quality/test_rms.py
@@ -2,7 +2,7 @@ import os
 import numpy
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 
-import unittest2 as unittest
+import unittest
 from tkp.quality.rms import rms_invalid
 
 from tkp import accessors

--- a/tests/test_sourcefinder/test_FDR.py
+++ b/tests/test_sourcefinder/test_FDR.py
@@ -37,7 +37,7 @@ of detected sources in the presence of correlated noise in a single map
 
 import os
 
-import unittest2 as unittest
+import unittest
 
 from tkp import accessors
 from tkp.sourcefinder import image

--- a/tests/test_sourcefinder/test_L15_12h_const.py
+++ b/tests/test_sourcefinder/test_L15_12h_const.py
@@ -4,7 +4,7 @@ Tests for simulated LOFAR datasets.
 
 import os
 
-import unittest2 as unittest
+import unittest
 
 import tkp.accessors.fitsimage
 import tkp.sourcefinder.image as image

--- a/tests/test_sourcefinder/test_errors.py
+++ b/tests/test_sourcefinder/test_errors.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest
 
 import math
 from tkp.utility.coordinates import WCS

--- a/tests/test_sourcefinder/test_gaussian.py
+++ b/tests/test_sourcefinder/test_gaussian.py
@@ -3,7 +3,7 @@ Tests for elliptical Gaussian fitting code in the TKP pipeline.
 """
 import numpy
 
-import unittest2 as unittest
+import unittest
 
 from tkp.sourcefinder.gaussian import gaussian
 from tkp.sourcefinder.fitting import moments, fitgaussian

--- a/tests/test_sourcefinder/test_image.py
+++ b/tests/test_sourcefinder/test_image.py
@@ -1,7 +1,7 @@
 import numpy as np
 import os
 
-import unittest2 as unittest
+import unittest
 
 from tkp.testutil.decorators import requires_data
 import tkp.sourcefinder

--- a/tests/test_sourcefinder/test_sf_utils.py
+++ b/tests/test_sourcefinder/test_sf_utils.py
@@ -3,7 +3,7 @@ from numpy.testing import assert_array_equal
 from collections import namedtuple
 from tkp.utility.uncertain import Uncertain
 
-import unittest2 as unittest
+import unittest
 
 from tkp.sourcefinder.utils import maximum_pixel_method_variance, fudge_max_pix
 from tkp.sourcefinder.utils import generate_result_maps

--- a/tests/test_sourcefinder/test_source_measurements.py
+++ b/tests/test_sourcefinder/test_source_measurements.py
@@ -16,7 +16,7 @@ deblending algorithm.
 import os
 import numpy as np
 
-import unittest2 as unittest
+import unittest
 
 import tkp.accessors
 from tkp.sourcefinder import image

--- a/tests/test_utility/test_coordinates.py
+++ b/tests/test_utility/test_coordinates.py
@@ -4,7 +4,7 @@ Test functions used for manipulating coordinates in the TKP pipeline.
 
 import pytz
 
-import unittest2 as unittest
+import unittest
 from pyrap.measures import measures
 
 import datetime

--- a/tests/test_utility/test_redirect_stream.py
+++ b/tests/test_utility/test_redirect_stream.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest
 import sys
 import resource
 from io import BytesIO

--- a/tests/test_utility/test_sigmaclip.py
+++ b/tests/test_utility/test_sigmaclip.py
@@ -1,6 +1,6 @@
 import numpy
 
-import unittest2 as unittest
+import unittest
 
 from tkp.utility import sigmaclip
 

--- a/tests/test_utility/test_substitute.py
+++ b/tests/test_utility/test_substitute.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest
 from tkp.utility import substitute_nan, substitute_inf
 
 class SubstituteInfTestCase(unittest.TestCase):

--- a/tests/test_utility/test_uncertain.py
+++ b/tests/test_utility/test_uncertain.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest
 from tkp.utility.uncertain import Uncertain
 
 class UncertainTestCase(unittest.TestCase):

--- a/tests/test_utility/test_wcs.py
+++ b/tests/test_utility/test_wcs.py
@@ -1,6 +1,6 @@
 import wcslib
 
-import unittest2 as unittest
+import unittest
 
 from tkp.utility import coordinates
 from tkp.sourcefinder import extract

--- a/tkp/testutil/decorators.py
+++ b/tkp/testutil/decorators.py
@@ -1,10 +1,6 @@
 import os
 import unittest
 
-
-if not  hasattr(unittest.TestCase, 'assertIsInstance'):
-    import unittest2 as unittest
-
 def requires_database():
     if os.environ.get("TKP_DISABLEDB", False):
         return unittest.skip("Database functionality disabled in configuration")


### PR DESCRIPTION
We no longer support Python earlier than 2.7, so unittest2 is of no benefit to
us.
