### PR TITLE
De-duplicate 1-to-1 association queries

### DIFF
--- a/tkp/db/monitoringlist.py
+++ b/tkp/db/monitoringlist.py
@@ -8,6 +8,7 @@ import logging, sys
 
 from tkp.db import execute as execute
 from tkp.db.associations import _empty_temprunningcatalog as _del_tempruncat
+from tkp.db.associations import ONE_TO_ONE_ASSOC_QUERY
 
 logger = logging.getLogger(__name__)
 
@@ -477,51 +478,7 @@ def _insert_1_to_1_assoc():
     The runcat-monitoring pairs are appended to the assocxtrsource
     (light-curve) table as a type = 9 datapoint.
     """
-    query = """\
-INSERT INTO assocxtrsource
-  (runcat
-  ,xtrsrc
-  ,type
-  ,distance_arcsec
-  ,r
-  ,v_int
-  ,eta_int
-  )
-  SELECT t.runcat
-        ,t.xtrsrc
-        ,9 AS type
-        ,0 AS distance_arcsec
-        ,0 AS r
-        ,t.v_int_inter / t.avg_f_int
-        ,t.eta_int_inter / t.avg_f_int_weight
-    FROM (SELECT runcat
-                ,xtrsrc
-                ,CASE WHEN avg_f_int = 0.0
-                      THEN 0.000001
-                      ELSE avg_f_int
-                 END AS avg_f_int
-                ,avg_f_int_weight
-                ,CASE WHEN f_datapoints = 1
-                      THEN 0
-                      ELSE CASE WHEN ABS(avg_f_int_sq - avg_f_int * avg_f_int) < 8e-14
-                                THEN 0
-                                ELSE SQRT(CAST(f_datapoints AS DOUBLE PRECISION)
-                                         * (avg_f_int_sq - avg_f_int * avg_f_int)
-                                         / (CAST(f_datapoints AS DOUBLE PRECISION) - 1.0)
-                                         )
-                           END
-                 END AS v_int_inter
-                ,CASE WHEN f_datapoints = 1
-                      THEN 0
-                      ELSE (CAST(f_datapoints AS DOUBLE PRECISION)
-                            / (CAST(f_datapoints AS DOUBLE PRECISION) - 1.0))
-                           * (avg_f_int_weight * avg_weighted_f_int_sq
-                             - avg_weighted_f_int * avg_weighted_f_int)
-                 END AS eta_int_inter
-            FROM temprunningcatalog
-           ) t
-"""
-    cursor = execute(query, commit=True)
+    cursor = execute(ONE_TO_ONE_ASSOC_QUERY, {'type': 9}, commit=True)
     cnt = cursor.rowcount
     if cnt > 0:
         logger.info("Inserted %s runcat-monitoring source pairs in assocxtrsource" % cnt)

--- a/tkp/db/nulldetections.py
+++ b/tkp/db/nulldetections.py
@@ -6,6 +6,7 @@ This module contains the routines to deal with null detections.
 import logging
 from tkp.db import execute as execute
 from tkp.db.associations import _empty_temprunningcatalog as _del_tempruncat
+from tkp.db.associations import ONE_TO_ONE_ASSOC_QUERY
 
 logger = logging.getLogger(__name__)
 
@@ -283,51 +284,7 @@ def _insert_1_to_1_assoc():
     differences might get too small to cause divisions by zero.
 
     """
-    query = """\
-INSERT INTO assocxtrsource
-  (runcat
-  ,xtrsrc
-  ,type
-  ,distance_arcsec
-  ,r
-  ,v_int
-  ,eta_int
-  )
-  SELECT t.runcat
-        ,t.xtrsrc
-        ,7 AS type
-        ,0 AS distance_arcsec
-        ,0 AS r
-        ,t.v_int_inter / t.avg_f_int
-        ,t.eta_int_inter / t.avg_f_int_weight
-    FROM (SELECT runcat
-                ,xtrsrc
-                ,CASE WHEN avg_f_int = 0.0
-                      THEN 0.000001
-                      ELSE avg_f_int
-                 END AS avg_f_int
-                ,avg_f_int_weight
-                ,CASE WHEN f_datapoints = 1
-                      THEN 0
-                      ELSE CASE WHEN ABS(avg_f_int_sq - avg_f_int * avg_f_int) < 8e-14
-                                THEN 0
-                                ELSE SQRT(CAST(f_datapoints AS DOUBLE PRECISION)
-                                         * (avg_f_int_sq - avg_f_int * avg_f_int)
-                                         / (CAST(f_datapoints AS DOUBLE PRECISION) - 1.0)
-                                         )
-                           END
-                 END AS v_int_inter
-                ,CASE WHEN f_datapoints = 1
-                      THEN 0
-                      ELSE (CAST(f_datapoints AS DOUBLE PRECISION)
-                            / (CAST(f_datapoints AS DOUBLE PRECISION) - 1.0))
-                           * (avg_f_int_weight * avg_weighted_f_int_sq
-                             - avg_weighted_f_int * avg_weighted_f_int)
-                 END AS eta_int_inter
-            FROM temprunningcatalog
-           ) t
-"""
-    cursor = execute(query, commit=True)
+    cursor = execute(ONE_TO_ONE_ASSOC_QUERY, {'type': 7}, commit=True)
     cnt = cursor.rowcount
     logger.info("Inserted %s 1-to-1 null detections in assocxtrsource" % cnt)
 


### PR DESCRIPTION
This avoids embedding basically the same query three times in three different source files.

This seems to work, and passes all the unit tests, so I think it's good to go. However: at the end of the old query in tkp.db.associations, there were an extra couple of joins:

```
WHERE tmprc.runcat = r.id
AND tmprc.xtrsrc = x.id
```

I can't see what good they were doing, and removing them hasn't broken any tests. I'd appreciate a sanity check before you carelessly hit the "merge" button, though!
