### PR TITLE
Add Chi-squared columns to extractedsource table.

### DIFF
--- a/documentation/devref/database/schema.rst
+++ b/documentation/devref/database/schema.rst
@@ -334,6 +334,11 @@ The TraP may add forced-fit entries to this table as well. Then
     1-sigma error (Jy) of ``f_int``, calculated by the sourcefinder
     procedures.
 
+**chisq, reduced_chisq**
+    Goodness of fit metrics for fitted Gaussian profiles.
+    (NB. These are not yet implemented, but have been placed in the schema
+    in advance, to avoid extra database migrations.)
+
 **extract_type**
     Reports how the source was extracted by sourcefinder (:ref:`Spreeuw (2010)
     <spreeuw-2010>`), Currently implemented values are:

--- a/tkp/db/database.py
+++ b/tkp/db/database.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 # The version of the TKP DB schema which is assumed by the current tree.
 # Increment whenever the schema changes.
-DB_VERSION = 33
+DB_VERSION = 34
 
 class DBExceptions(object):
     """

--- a/tkp/db/sql/statements/tables/extractedsource.sql
+++ b/tkp/db/sql/statements/tables/extractedsource.sql
@@ -26,6 +26,8 @@ CREATE TABLE extractedsource
   ,f_peak_err DOUBLE PRECISION NULL
   ,f_int DOUBLE PRECISION NULL
   ,f_int_err DOUBLE PRECISION NULL
+  ,chisq DOUBLE PRECISION NULL
+  ,reduced_chisq DOUBLE PRECISION NULL
   ,extract_type SMALLINT NULL
   ,fit_type SMALLINT NULL
   ,ff_runcat INT NULL


### PR DESCRIPTION
This is in anticipation of storing goodness-of-fit values from the
sourcefinder.
https://support.astron.nl/lofar_issuetracker/issues/6591
