### PR TITLE
Fix inject.py file check

### DIFF
--- a/tkp/inject.py
+++ b/tkp/inject.py
@@ -96,7 +96,7 @@ def main():
     for target_file in target_files:
         #Normally accessors.open checks this, but we're going straight 
         #to detect here because we don't want to actually open it:
-        if not os.path.isfile(target_file) or os.path.isdir(target_file):
+        if not os.path.isfile(target_file) and not os.path.isdir(target_file):
             print "File not found: %s (check path is correct?)" % target_file
             continue
         print "injecting data into %s" % target_file

--- a/tkp/inject.py
+++ b/tkp/inject.py
@@ -96,7 +96,7 @@ def main():
     for target_file in target_files:
         #Normally accessors.open checks this, but we're going straight 
         #to detect here because we don't want to actually open it:
-        if not os.path.isfile(target_file) and not os.path.isdir(target_file):
+        if not (os.path.isfile(target_file) or os.path.isdir(target_file)):
             print "File not found: %s (check path is correct?)" % target_file
             continue
         print "injecting data into %s" % target_file


### PR DESCRIPTION
Fixed missing brackets around file check logic. Otherwise a directory (i.e. CASA file) would never be found when using tkp-inject.py.