### PR TITLE
Simplify accessors.

### DIFF
--- a/tests/test_accessors/test_lofarcasatable.py
+++ b/tests/test_accessors/test_lofarcasatable.py
@@ -12,11 +12,10 @@ from tkp.testutil.data import DATAPATH
 
 casatable = os.path.join(DATAPATH, 'casatable/L55596_000TO009_skymodellsc_wmax6000_noise_mult10_cell40_npix512_wplanes215.img.restored.corr')
 
+@requires_data(casatable)
 class TestLofarCasaImage(unittest.TestCase):
-    @classmethod
-    @requires_data(casatable)
-    def setUpClass(cls):
-        cls.accessor = LofarCasaImage(casatable)
+    def setUp(self):
+        self.accessor = LofarCasaImage(casatable)
 
     def test_casaimage(self):
         self.assertTrue(isinstance(self.accessor, LofarAccessor))
@@ -74,9 +73,12 @@ class TestLofarCasaImage(unittest.TestCase):
         self.assertEqual(LofarCasaImage.non_overlapping_time(series), answer)
 
     def test_parse_tautime(self):
+        """
+        Insert some mock data in self.subtables, check it parses correctly.
+        """
         class MockOriginTable:
             def col(self, name):
                 if name == 'START': return [100, 100, 200]
                 elif name == 'END': return [150, 175, 300]
-        subtables = {'LOFAR_ORIGIN': MockOriginTable()}
-        self.assertEqual(LofarCasaImage.parse_tautime(subtables), 175)
+        self.accessor.subtables = {'LOFAR_ORIGIN': MockOriginTable()}
+        self.assertEqual(self.accessor.parse_tautime(), 175)

--- a/tkp/accessors/amicasaimage.py
+++ b/tkp/accessors/amicasaimage.py
@@ -27,7 +27,5 @@ class AmiCasaImage(CasaImage):
     """
     def __init__(self, url, plane=0, beam=None):
         super(AmiCasaImage, self).__init__(url, plane, beam)
-
-        table = pyrap_table(self.url.encode(), ack=False)
-        self.taustart_ts = self.parse_taustartts(table)
+        self.taustart_ts = self.parse_taustartts()
         self.tau_time = 1 # Placeholder value until properly implemented

--- a/tkp/accessors/dataaccessor.py
+++ b/tkp/accessors/dataaccessor.py
@@ -102,18 +102,17 @@ class DataAccessor(object):
             'deltay': self.pixelsize[1],
         }
 
-    @staticmethod
-    def parse_pixelsize(wcs):
+    def parse_pixelsize(self):
         """
-        Arguments:
-          - wcs: A tkp.coordinates.wcs.WCS object
 
         Returns:
           - deltax: pixel size along the x axis in degrees
           - deltay: pixel size along the x axis in degrees
 
         """
-        #Would have to be pretty strange data for this not to be the case
+        wcs = self.wcs
+        # Check that pixels are square
+        # (Would have to be pretty strange data for this not to be the case)
         assert wcs.cunit[0] == wcs.cunit[1]
         if wcs.cunit[0] == "deg":
             deltax = wcs.cdelt[0]

--- a/tkp/accessors/kat7casaimage.py
+++ b/tkp/accessors/kat7casaimage.py
@@ -27,8 +27,6 @@ class Kat7CasaImage(CasaImage):
     """
     def __init__(self, url, plane=0, beam=None):
         super(Kat7CasaImage, self).__init__(url, plane, beam)
-
-        table = pyrap_table(self.url.encode(), ack=False)
-        self.taustart_ts = self.parse_taustartts(table)
-        self.tau_time= 1 # Placeholder value
+        self.taustart_ts = self.parse_taustartts()
+        self.tau_time = 1 # Placeholder value
 

--- a/tkp/testutil/mock.py
+++ b/tkp/testutil/mock.py
@@ -27,52 +27,14 @@ class MockImage(DataAccessor):
             wcs (tkp.utility.coordinates.WCS): WCS for the image.
         """
         self.keywords = keywords
-        self._wcs = wcs
-
-    @property
-    def wcs(self):
-        return self._wcs
-
-    @property
-    def data(self):
-        return numpy.array([[[[0]]]])
-
-    @property
-    def url(self):
-        return self.keywords["url"]
-
-    @property
-    def pixelsize(self):
-        return DataAccessor.parse_pixelsize(self.wcs)
-
-    @property
-    def tau_time(self):
-        return self.keywords["tau_time"]
-
-    @property
-    def taustart_ts(self):
-        return self.keywords["taustart_ts"]
-
-    def get_centre_ra(self):
-        return self.keywords["centre_ra"]
-    def set_centre_ra(self, x):
-        self.keywords["centre_ra"] = x
-    centre_ra = property(get_centre_ra, set_centre_ra)
-
-    def get_centre_decl(self):
-        return self.keywords["centre_decl"]
-    def set_centre_decl(self, x):
-        self.keywords["centre_decl"] = x
-    centre_decl = property(get_centre_decl, set_centre_decl)
-
-    @property
-    def freq_eff(self):
-        return self.keywords["freq_eff"]
-
-    @property
-    def freq_bw(self):
-        return self.keywords["freq_bw"]
-
-    @property
-    def beam(self):
-        return self.keywords["beam"]
+        self.wcs = wcs
+        self.data = numpy.array([[[[0]]]])
+        self.url = self.keywords["url"]
+        self.pixelsize = self.parse_pixelsize()
+        self.tau_time = self.keywords["tau_time"]
+        self.taustart_ts = self.keywords["taustart_ts"]
+        self.centre_ra = self.keywords["centre_ra"]
+        self.centre_decl = self.keywords["centre_decl"]
+        self.freq_eff = self.keywords["freq_eff"]
+        self.freq_bw = self.keywords["freq_bw"]
+        self.beam = self.keywords["beam"]


### PR DESCRIPTION
As @gijzelaerr suggested, It's simpler to use regular methods. It also ends up being more flexible since you can override functions to use different input data.

However, we can keep the clarity of attribute assignment by having these methods return their parsed data, rather than simply assigning it as a side-effect.