### PR TITLE
Add a SQLAlchemy based backend

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -6,12 +6,12 @@ The following people have directly contributed to development of this
 code-base, either through coding, documentation, or extensive user-testing and
 feedback. Entries are sorted alphabetically by surname.
 
-See also the `TraP paper`_ (pending submission), which provides a fully referenced description of the
+See also the `TraP paper`_, which provides a fully referenced description of the
 TraP functionality as of release 2.0, and gives attribution to the wider
 collaboration which made TraP development possible.
 
 
-.. _TraP paper: http://arxiv.org/list/xxxx.xxxx
+.. _TraP paper: http://adsabs.harvard.edu/abs/2015arXiv150301526S
 
 - Martin Bell (2007 - 2012)
 - Jess Broderick (2009 - present)

--- a/README.rst
+++ b/README.rst
@@ -7,9 +7,10 @@ astronomical images. It primarily targets LOFAR data, but is also applicable
 to a range of other instruments.  See the `pipeline documentation`_ for
 details including installation instructions and a usage guide.
 
-An overview of the TraP will be published in the forthcoming `TraP paper`_
-(currently undergoing journal review),
-and we already have an assigned ASCL ID (http://ascl.net/1412.011).
+An overview of the TraP can be found in the `TraP paper`_ accompanying
+release 2.0, and we also have an assigned ASCL ID (http://ascl.net/1412.011).
+If you make use of TraP in work leading to a publication, we ask that you cite
+these references.
 
 
 TraP development is coordinated by `The LOFAR Transients Key Science Project`_.
@@ -20,7 +21,7 @@ tracker`_. Contributions are welcome.
 This is open source software: see ``COPYING`` for licensing and copyright
 information.
 
-.. _TraP paper: https://github.com/transientskp/trap-paper
+.. _TraP paper: http://adsabs.harvard.edu/abs/2015arXiv150301526S
 .. _The LOFAR Transients Key Science Project: http://www.transientskp.org/
 .. _pipeline documentation: http://docs.transientskp.org/
 .. _issue tracker: https://github.com/transientskp/tkp/issues

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@ pyfits>=2.3.1
 python-dateutil>=1.4.1
 pytz
 pywcs
+sqlalchemy>=1.0.0
+
 #pyrap>=1.1.0  # not available on pip
 
 ## If you require distributed processing:
@@ -16,4 +18,5 @@ pymongo
 psycopg2
 
 ## if you want to use the monetdb storage backend
-#python-monetdb>=11.11.11
+#pymonetdb>=0.1
+#sqlalchemy_monetdb>=0.9.1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -119,8 +119,8 @@ class DatabaseConfigTestCase(unittest.TestCase):
         db_config = get_database_config()
         self.assertEqual(db_config['engine'], "monetdb")
         self.assertEqual(db_config['database'], username)
-        self.assertEqual(db_config['user'], username)
-        self.assertEqual(db_config['password'], username)
+        self.assertEqual(db_config['user'], "monetdb")
+        self.assertEqual(db_config['password'], "monetdb")
         self.assertEqual(db_config['host'], "localhost")
         self.assertEqual(db_config['port'], 50000)
 

--- a/tests/test_database/test_algorithms.py
+++ b/tests/test_database/test_algorithms.py
@@ -1,6 +1,7 @@
 import unittest
 from tkp.db.orm import DataSet, Image
 import tkp.db
+import tkp.db.database
 from tkp.testutil.decorators import requires_database
 from tkp.testutil import db_subs
 from tkp.db.generic import columns_from_table
@@ -12,8 +13,10 @@ new_source_sigma_margin = 3
 class TestSourceAssociation(unittest.TestCase):
     @requires_database()
     def setUp(self):
+        self.database = tkp.db.database.Database()
         self.dataset = DataSet(data={'description': "Src. assoc:" +
-                                                    self._testMethodName})
+                                                    self._testMethodName},
+                               database=self.database)
 
         self.im_params = db_subs.generate_timespaced_dbimages_data(n_images=8)
         self.db_imgs=[]

--- a/tests/test_database/test_associations.py
+++ b/tests/test_database/test_associations.py
@@ -4,6 +4,8 @@ from io import BytesIO
 
 import unittest
 
+from sqlalchemy.exc import IntegrityError
+
 import tkp.db
 import tkp.db.general as dbgen
 from tkp.db.orm import DataSet
@@ -12,6 +14,7 @@ from tkp.db.associations import associate_extracted_sources
 from tkp.db.generic import columns_from_table, get_db_rows_as_dicts
 from tkp.testutil import db_subs
 from tkp.testutil.decorators import requires_database
+
 
 # Use a default argument value for convenience
 from functools import partial
@@ -1337,8 +1340,8 @@ class TestMany2Many(unittest.TestCase):
         hdlr = logging.StreamHandler(iostream)
         logging.getLogger().addHandler(hdlr)
 
-        # Raises an error, exact type depends on database engine in use:
-        with self.assertRaises(tkp.db.Database().exceptions.RhombusError):
+        # Raises an error
+        with self.assertRaises(IntegrityError):
             runcat, extracted = self.insert_many_to_many_sources(dataset,
                                              self.im_params,
                                              self.base_srcs, image2_srcs,
@@ -1346,4 +1349,4 @@ class TestMany2Many(unittest.TestCase):
         logging.getLogger().removeHandler(hdlr)
 
         # We want to be sure that the error has been appropriately logged.
-        self.assertIn("RhombusError", iostream.getvalue())
+        self.assertIn(IntegrityError.__name__, iostream.getvalue())

--- a/tests/test_database/test_configstore.py
+++ b/tests/test_database/test_configstore.py
@@ -3,6 +3,7 @@ from tkp.db.configstore import store_config, fetch_config
 from tkp.db import rollback, execute, Database
 from tkp.db.general import insert_dataset
 from tkp.testutil.decorators import requires_database
+from sqlalchemy.exc import IntegrityError
 
 
 config = {'section1': {'key1': 'value1', 'key2': 2},
@@ -62,9 +63,5 @@ class TestConfigStore(unittest.TestCase):
         """
         store_config(config, self.dataset_id)
         database = Database()
-        if database.engine == "monetdb":
-            # monetdb raises an OperationalError here, postgres (and probably others IntegrityError)
-            exception = database.connection.OperationalError
-        else:
-            exception = database.connection.IntegrityError
-        self.assertRaises(exception, store_config, config, self.dataset_id)
+        with self.assertRaises(IntegrityError):
+            store_config(config, self.dataset_id)

--- a/tests/test_database/test_connector.py
+++ b/tests/test_database/test_connector.py
@@ -28,14 +28,12 @@ class TestDatabaseConnection(unittest.TestCase):
             "NotSupportedError"
         ]
 
-        # In addition, we define our own exception types:
-        exceptions.append("RhombusError")
 
         # All DB-API exceptions are subclasses of StandardError:
         for exception in exceptions:
             self.assertTrue(
                 issubclass(
-                    getattr(self.database.exceptions, exception),
+                    getattr(self.database.connection.connection.connection, exception),
                     StandardError
                 )
             )

--- a/tests/test_database/test_general.py
+++ b/tests/test_database/test_general.py
@@ -10,7 +10,7 @@ from tkp.testutil.decorators import requires_database
 class TestProcessTime(unittest.TestCase):
     def test_set_process_timestamps(self):
         dataset = DataSet(data={'description': 'test dataset'})
-        time.sleep(1)
+        time.sleep(3)
         update_dataset_process_end_ts(dataset.id)
         start_time, end_time = db_query("""
             SELECT process_start_ts, process_end_ts

--- a/tests/test_database/test_sql/test_median.py
+++ b/tests/test_database/test_sql/test_median.py
@@ -1,6 +1,6 @@
 import unittest
 import tkp
-from tkp.db import execute, rollback, Database
+from tkp.db import execute, Database
 from tkp.testutil import db_subs
 from numpy import median
 

--- a/tests/test_quality/test_reject.py
+++ b/tests/test_quality/test_reject.py
@@ -3,6 +3,7 @@ import tkp.quality
 import tkp.db
 import tkp.db.quality
 import tkp.db.database
+from sqlalchemy.exc import DatabaseError
 from tkp.testutil.decorators import requires_database
 from tkp.testutil import db_subs
 
@@ -37,7 +38,7 @@ class TestReject(unittest.TestCase):
         self.assertEqual(cursor.fetchone()[0], 0)
 
     def test_unknownreason(self):
-        self.assertRaises(tkp.db.database.Database().connection.DatabaseError,
+        self.assertRaises(DatabaseError,
               tkp.db.quality.reject, self.image.id, 666666, "bad reason")
 
     def test_isrejected(self):

--- a/tkp/db/__init__.py
+++ b/tkp/db/__init__.py
@@ -16,50 +16,10 @@ def execute(query, parameters={}, commit=False):
 
     :returns: a database cursor object
     """
-    #logger.info('executing query\n%s' % query % parameters)
     database = Database()
-    cursor = database.connection.cursor()
-    try:
-        cursor.execute(query, sanitize_db_inputs(parameters))
-        if commit:
-            database.connection.commit()
-    except database.connection.Error as e:
-        logger.error("Query failed: %s. Query: %s." % (e, query % parameters))
-        raise
-    except Exception as e:
-        logger.error("Big problem here: %s" % e)
-        raise
-    return cursor
+    return database.execute(query, parameters=parameters, commit=commit)
 
-def commit():
-    """
-    A generic wrapper to commit a query transaction
-
-    It saves the changes involved by a transaction
-    """
-    database = Database()
-    return database.connection.commit()
 
 def rollback():
-    """
-    A generic wrapper to rollback a query transaction
-
-    Undo changes involved by a transaction that have not been saved
-    """
     database = Database()
-    return database.connection.rollback()
-
-def connect():
-    """
-    A generic wrapper to connect to the configured database
-    """
-    database = Database()
-    return database.connect()
-
-def connection():
-    """
-    A generic wrapper to create a connection to the database if
-    it does not exist
-    """
-    database = Database()
-    return database.connection
+    return database.rollback()

--- a/tkp/db/associations.py
+++ b/tkp/db/associations.py
@@ -4,6 +4,7 @@ deal with source association.
 """
 import logging
 import tkp.db
+from sqlalchemy.exc import IntegrityError
 
 
 logger = logging.getLogger(__name__)
@@ -50,9 +51,9 @@ def associate_extracted_sources(image_id, deRuiter_r, new_source_sigma_margin):
     #+------------------------------------------------------+
     try:
         _insert_1_to_many_runcat()
-    except tkp.db.Database().exceptions.RhombusError as e:
+    except IntegrityError as e:
         logger.error("Error caught around _insert_1_to_many_runcat - "
-                 "possible 'RhombusError'. See Issue #4778. Will now re-raise.")
+                 "possible 'IntegrityError'. See Issue #4778. Will now re-raise.")
         raise e
 
     _flag_1_to_many_inactive_runcat()

--- a/tkp/db/database.py
+++ b/tkp/db/database.py
@@ -4,6 +4,7 @@ import numpy
 import tkp.config
 from tkp.utility import substitute_inf
 from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 
 
 logger = logging.getLogger(__name__)
@@ -56,6 +57,7 @@ class Database(object):
 
     # this makes this class a singleton
     _instance = None
+
     def __new__(cls, *args, **kwargs):
         if not cls._instance:
             cls._instance = object.__new__(cls)
@@ -63,7 +65,8 @@ class Database(object):
 
     def __init__(self, **kwargs):
         if self._configured:
-            if kwargs: logger.warning("Not configuring pre-configured database")
+            if kwargs:
+                logger.warning("Not configuring pre-configured database")
             return
         elif not kwargs:
             kwargs = tkp.config.get_database_config()
@@ -97,9 +100,9 @@ class Database(object):
                                              self.host,
                                              self.port,
                                              self.database),
-                                            echo=True
+                                            echo=False
                                             )
-
+        self.Session = sessionmaker(bind=self.alchemy_engine)
         self._connection = self.alchemy_engine.connect()
         self._connection.execution_options(autocommit=False)
 
@@ -122,7 +125,6 @@ class Database(object):
                                                             self.host,
                                                             self.port,
                                                             self.database))
-
 
     @property
     def connection(self):

--- a/tkp/db/model.py
+++ b/tkp/db/model.py
@@ -1,0 +1,378 @@
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Index,\
+    Integer, SmallInteger, String, text, Sequence
+from sqlalchemy.orm import relationship
+from sqlalchemy.ext.declarative import declarative_base
+
+from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION as Double
+
+
+
+Base = declarative_base()
+metadata = Base.metadata
+
+
+class Assocskyrgn(Base):
+    __tablename__ = 'assocskyrgn'
+
+    id = Column(Integer, primary_key=True)
+    runcat = Column(ForeignKey('runningcatalog.id'), nullable=False, index=True)
+    skyrgn = Column(ForeignKey('skyregion.id'), nullable=False, index=True)
+    distance_deg = Column(Double)
+
+    runningcatalog = relationship('Runningcatalog')
+    skyregion = relationship('Skyregion')
+
+
+class Assocxtrsource(Base):
+    __tablename__ = 'assocxtrsource'
+    __table_args__ = (
+        Index('assocxtrsource_runcat_xtrsrc_key', 'runcat', 'xtrsrc',
+              unique=True),
+    )
+
+    id = Column(Integer, primary_key=True)
+    runcat = Column(ForeignKey('runningcatalog.id'), nullable=False)
+    xtrsrc = Column(ForeignKey('extractedsource.id'), index=True)
+    type = Column(SmallInteger, nullable=False)
+    distance_arcsec = Column(Double)
+    r = Column(Double)
+    loglr = Column(Double)
+    v_int = Column(Double, nullable=False)
+    eta_int = Column(Double, nullable=False)
+    f_datapoints = Column(Integer, nullable=False)
+
+    runningcatalog = relationship('Runningcatalog')
+    extractedsource = relationship('Extractedsource')
+
+
+class Config(Base):
+    __tablename__ = 'config'
+    __table_args__ = (
+        Index('config_dataset_section_key_key', 'dataset', 'section', 'key',
+              unique=True),
+    )
+
+    id = Column(Integer, primary_key=True)
+    dataset = Column(ForeignKey('dataset.id'), nullable=False)
+    section = Column(String(100))
+    key = Column(String(100))
+    value = Column(String(500))
+    type = Column(String(5))
+
+    dataset1 = relationship('Dataset')
+
+
+seq_dataset = Sequence('seq_dataset')
+
+class Dataset(Base):
+    __tablename__ = 'dataset'
+
+    id = Column(Integer, seq_dataset, server_default=seq_dataset.next_value(),
+                primary_key=True)
+    rerun = Column(Integer, nullable=False, server_default=text("0"))
+    type = Column(SmallInteger, nullable=False, server_default=text("1"))
+    process_start_ts = Column(DateTime, nullable=False)
+    process_end_ts = Column(DateTime)
+    detection_threshold = Column(Double)
+    analysis_threshold = Column(Double)
+    assoc_radius = Column(Double)
+    backsize_x = Column(SmallInteger)
+    backsize_y = Column(SmallInteger)
+    margin_width = Column(Double)
+    description = Column(String(100), nullable=False)
+    node = Column(SmallInteger, nullable=False, server_default=text("1"))
+    nodes = Column(SmallInteger, nullable=False, server_default=text("1"))
+
+
+class Extractedsource(Base):
+    __tablename__ = 'extractedsource'
+
+    id = Column(Integer, primary_key=True)
+    image = Column(ForeignKey('image.id'), nullable=False, index=True)
+    zone = Column(Integer, nullable=False)
+    ra = Column(Double, nullable=False, index=True)
+    decl = Column(Double, nullable=False, index=True)
+    uncertainty_ew = Column(Double, nullable=False)
+    uncertainty_ns = Column(Double, nullable=False)
+    ra_err = Column(Double, nullable=False, index=True)
+    decl_err = Column(Double, nullable=False, index=True)
+    ra_fit_err = Column(Double, nullable=False)
+    decl_fit_err = Column(Double, nullable=False)
+    ew_sys_err = Column(Double, nullable=False)
+    ns_sys_err = Column(Double, nullable=False)
+    error_radius = Column(Double, nullable=False)
+    x = Column(Double, nullable=False, index=True)
+    y = Column(Double, nullable=False, index=True)
+    z = Column(Double, nullable=False, index=True)
+    racosdecl = Column(Double, nullable=False)
+    margin = Column(Boolean, nullable=False, server_default=text("false"))
+    det_sigma = Column(Double, nullable=False)
+    semimajor = Column(Double)
+    semiminor = Column(Double)
+    pa = Column(Double)
+    f_peak = Column(Double)
+    f_peak_err = Column(Double)
+    f_int = Column(Double)
+    f_int_err = Column(Double)
+    chisq = Column(Double)
+    reduced_chisq = Column(Double)
+    extract_type = Column(SmallInteger)
+    fit_type = Column(SmallInteger)
+    ff_runcat = Column(ForeignKey('runningcatalog.id'))
+    ff_monitor = Column(ForeignKey('monitor.id'))
+    node = Column(SmallInteger, nullable=False, server_default=text("1"))
+    nodes = Column(SmallInteger, nullable=False, server_default=text("1"))
+
+    monitor = relationship('Monitor')
+    runningcatalog = relationship('Runningcatalog',
+                                  primaryjoin='Extractedsource.ff_runcat == Runningcatalog.id')
+    image1 = relationship('Image')
+
+
+seq_frequencyband = Sequence('seq_frequencyband')
+
+
+class Frequencyband(Base):
+    __tablename__ = 'frequencyband'
+
+    id = Column(Integer, seq_frequencyband, primary_key=True,
+                server_default=seq_frequencyband.next_value())
+    freq_central = Column(Double)
+    freq_low = Column(Double)
+    freq_high = Column(Double)
+
+
+seq_image = Sequence('seq_image')
+
+
+class Image(Base):
+    __tablename__ = 'image'
+
+    id = Column(Integer, seq_image, primary_key=True,
+                server_default=seq_image.next_value())
+    dataset = Column(ForeignKey('dataset.id'), nullable=False, index=True)
+    tau = Column(Integer)
+    band = Column(ForeignKey('frequencyband.id'), nullable=False, index=True)
+    stokes = Column(SmallInteger, nullable=False, server_default=text("1"))
+    tau_time = Column(Double)
+    freq_eff = Column(Double, nullable=False)
+    freq_bw = Column(Double)
+    taustart_ts = Column(DateTime, nullable=False, index=True)
+    skyrgn = Column(ForeignKey('skyregion.id'), nullable=False, index=True)
+    rb_smaj = Column(Double, nullable=False)
+    rb_smin = Column(Double, nullable=False)
+    rb_pa = Column(Double, nullable=False)
+    deltax = Column(Double, nullable=False)
+    deltay = Column(Double, nullable=False)
+    fwhm_arcsec = Column(Double)
+    fov_degrees = Column(Double)
+    rms_qc = Column(Double, nullable=False)
+    rms_min = Column(Double)
+    rms_max = Column(Double)
+    detection_thresh = Column(Double)
+    analysis_thresh = Column(Double)
+    url = Column(String(1024))
+    node = Column(SmallInteger, nullable=False, server_default=text("1"))
+    nodes = Column(SmallInteger, nullable=False, server_default=text("1"))
+
+    frequencyband = relationship('Frequencyband')
+    dataset1 = relationship('Dataset')
+    skyregion = relationship('Skyregion')
+
+
+class Monitor(Base):
+    __tablename__ = 'monitor'
+
+    id = Column(Integer, primary_key=True)
+    dataset = Column(ForeignKey('dataset.id'), nullable=False, index=True)
+    ra = Column(Double, nullable=False)
+    decl = Column(Double, nullable=False)
+    runcat = Column(ForeignKey('runningcatalog.id'))
+    name = Column(String(100))
+
+    dataset1 = relationship('Dataset')
+    runningcatalog = relationship('Runningcatalog')
+
+
+class Newsource(Base):
+    __tablename__ = 'newsource'
+
+    id = Column(Integer, primary_key=True)
+    runcat = Column(ForeignKey('runningcatalog.id'), nullable=False, index=True)
+    trigger_xtrsrc = Column(ForeignKey('extractedsource.id'), nullable=False,
+                            index=True)
+    newsource_type = Column(SmallInteger, nullable=False)
+    previous_limits_image = Column(ForeignKey('image.id'), nullable=False)
+
+    image = relationship('Image')
+    runningcatalog = relationship('Runningcatalog')
+    extractedsource = relationship('Extractedsource')
+
+
+class Node(Base):
+    __tablename__ = 'node'
+    __table_args__ = (
+        Index('node_node_zone_key', 'node', 'zone', unique=True),
+    )
+
+    id = Column(Integer, primary_key=True)
+    node = Column(SmallInteger, nullable=False, server_default=text("1"))
+    zone = Column(SmallInteger, nullable=False)
+    zone_min = Column(SmallInteger)
+    zone_max = Column(SmallInteger)
+    zone_min_incl = Column(Boolean, server_default=text("true"))
+    zone_max_incl = Column(Boolean, server_default=text("false"))
+    zoneheight = Column(Double, server_default=text("1.0"))
+    nodes = Column(SmallInteger, nullable=False, server_default=text("1"))
+
+
+class Rejection(Base):
+    __tablename__ = 'rejection'
+
+    id = Column(Integer, primary_key=True)
+    image = Column(ForeignKey('image.id'), index=True)
+    rejectreason = Column(ForeignKey('rejectreason.id'), index=True)
+    comment = Column(String(512))
+
+    image1 = relationship('Image')
+    rejectreason1 = relationship('Rejectreason')
+
+
+class Rejectreason(Base):
+    __tablename__ = 'rejectreason'
+
+    id = Column(Integer,  primary_key=True)
+    description = Column(String(512))
+
+
+class Runningcatalog(Base):
+    __tablename__ = 'runningcatalog'
+
+    id = Column(Integer, primary_key=True)
+    xtrsrc = Column(ForeignKey('extractedsource.id'), nullable=False,
+                    unique=True)
+    dataset = Column(ForeignKey('dataset.id'), nullable=False, index=True)
+    datapoints = Column(Integer, nullable=False)
+    zone = Column(Integer, nullable=False, index=True)
+    wm_ra = Column(Double, nullable=False, index=True)
+    wm_decl = Column(Double, nullable=False, index=True)
+    wm_uncertainty_ew = Column(Double, nullable=False, index=True)
+    wm_uncertainty_ns = Column(Double, nullable=False, index=True)
+    avg_ra_err = Column(Double, nullable=False)
+    avg_decl_err = Column(Double, nullable=False)
+    avg_wra = Column(Double, nullable=False)
+    avg_wdecl = Column(Double, nullable=False)
+    avg_weight_ra = Column(Double, nullable=False)
+    avg_weight_decl = Column(Double, nullable=False)
+    x = Column(Double, nullable=False, index=True)
+    y = Column(Double, nullable=False, index=True)
+    z = Column(Double, nullable=False, index=True)
+    inactive = Column(Boolean, nullable=False, server_default=text("false"))
+    mon_src = Column(Boolean, nullable=False, server_default=text("false"))
+
+    dataset1 = relationship('Dataset')
+    extractedsource = relationship('Extractedsource',
+                                   primaryjoin='Runningcatalog.xtrsrc == Extractedsource.id')
+
+
+class RunningcatalogFlux(Base):
+    __tablename__ = 'runningcatalog_flux'
+    __table_args__ = (
+        Index('runningcatalog_flux_runcat_band_stokes_key', 'runcat', 'band',
+              'stokes', unique=True),
+    )
+
+    id = Column(Integer, primary_key=True)
+    runcat = Column(ForeignKey('runningcatalog.id'), nullable=False)
+    band = Column(ForeignKey('frequencyband.id'), nullable=False, index=True)
+    stokes = Column(SmallInteger, nullable=False, server_default=text("1"))
+    f_datapoints = Column(Integer, nullable=False)
+    avg_f_peak = Column(Double)
+    avg_f_peak_sq = Column(Double)
+    avg_f_peak_weight = Column(Double)
+    avg_weighted_f_peak = Column(Double)
+    avg_weighted_f_peak_sq = Column(Double)
+    avg_f_int = Column(Double)
+    avg_f_int_sq = Column(Double)
+    avg_f_int_weight = Column(Double)
+    avg_weighted_f_int = Column(Double)
+    avg_weighted_f_int_sq = Column(Double)
+
+    frequencyband = relationship('Frequencyband')
+    runningcatalog = relationship('Runningcatalog')
+
+
+seq_skyregion = Sequence('seq_skyregion')
+
+
+class Skyregion(Base):
+    __tablename__ = 'skyregion'
+
+    id = Column(Integer, seq_skyregion, primary_key=True,
+                server_default=seq_skyregion.next_value())
+    dataset = Column(ForeignKey('dataset.id'), nullable=False, index=True)
+    centre_ra = Column(Double, nullable=False)
+    centre_decl = Column(Double, nullable=False)
+    xtr_radius = Column(Double, nullable=False)
+    x = Column(Double, nullable=False)
+    y = Column(Double, nullable=False)
+    z = Column(Double, nullable=False)
+
+    dataset1 = relationship('Dataset')
+
+
+class Temprunningcatalog(Base):
+    __tablename__ = 'temprunningcatalog'
+
+    id = Column(Integer, primary_key=True)
+    runcat = Column(ForeignKey('runningcatalog.id'), nullable=False, index=True)
+    xtrsrc = Column(ForeignKey('extractedsource.id'), nullable=False, index=True)
+    distance_arcsec = Column(Double, nullable=False)
+    r = Column(Double, nullable=False)
+    dataset = Column(ForeignKey('dataset.id'), nullable=False, index=True)
+    band = Column(ForeignKey('frequencyband.id'), nullable=False, index=True)
+    stokes = Column(SmallInteger, nullable=False, server_default=text("1"))
+    datapoints = Column(Integer, nullable=False)
+    zone = Column(Integer, nullable=False)
+    wm_ra = Column(Double, nullable=False)
+    wm_decl = Column(Double, nullable=False)
+    wm_uncertainty_ew = Column(Double, nullable=False)
+    wm_uncertainty_ns = Column(Double, nullable=False)
+    avg_ra_err = Column(Double, nullable=False)
+    avg_decl_err = Column(Double, nullable=False)
+    avg_wra = Column(Double, nullable=False)
+    avg_wdecl = Column(Double, nullable=False)
+    avg_weight_ra = Column(Double, nullable=False)
+    avg_weight_decl = Column(Double, nullable=False)
+    x = Column(Double, nullable=False)
+    y = Column(Double, nullable=False)
+    z = Column(Double, nullable=False)
+    margin = Column(Boolean, nullable=False, server_default=text("false"))
+    inactive = Column(Boolean, nullable=False, server_default=text("false"))
+    beam_semimaj = Column(Double)
+    beam_semimin = Column(Double)
+    beam_pa = Column(Double)
+    f_datapoints = Column(Integer)
+    avg_f_peak = Column(Double)
+    avg_f_peak_sq = Column(Double)
+    avg_f_peak_weight = Column(Double)
+    avg_weighted_f_peak = Column(Double)
+    avg_weighted_f_peak_sq = Column(Double)
+    avg_f_int = Column(Double)
+    avg_f_int_sq = Column(Double)
+    avg_f_int_weight = Column(Double)
+    avg_weighted_f_int = Column(Double)
+    avg_weighted_f_int_sq = Column(Double)
+
+    frequencyband = relationship('Frequencyband')
+    dataset1 = relationship('Dataset')
+    runningcatalog = relationship('Runningcatalog')
+    extractedsource = relationship('Extractedsource')
+
+
+class Version(Base):
+    __tablename__ = 'version'
+
+    name = Column(String(12), primary_key=True)
+    value = Column(Integer, nullable=False)

--- a/tkp/db/orm.py
+++ b/tkp/db/orm.py
@@ -214,8 +214,9 @@ class DBObject(object):
             try:
                 # Insert a default source
                 cursor.execute(query, values)
-                if not self.database.connection.autocommit:
-                    self.database.connection.commit()
+                if not self.database.connection.connection.autocommit:
+                    self.database.connection.connection.commit()
+
                 if self.database.engine == "monetdb":
                     self._id = cursor.lastrowid
                 elif self.database.engine == "postgresql":
@@ -223,6 +224,7 @@ class DBObject(object):
                 else:
                     raise self.database.connection.Error(
                          "Database engine not implemented in ORM.")
+
             except self.database.connection.Error:
                 logger.warn("insertion into database failed: %s",
                              (query % values))
@@ -264,7 +266,8 @@ class DBObject(object):
         # Shallow copy, but that's ok: all database values are
         # immutable (including datetime objects)
         if results:
-            self._data = results[0].copy()
+            # force to dict since sqlalchemy RowProxy doesn't have a copy
+            self._data = dict(results[0]).copy()
         else:
             self._data = {}
 

--- a/tkp/db/quality.py
+++ b/tkp/db/quality.py
@@ -72,7 +72,7 @@ def isrejected(imageid):
     cursor = tkp.db.execute(query)
     results = cursor.fetchall()
     if len(results) > 0:
-        return ["%s: %s" % row for row in results]
+        return ["%s: %s" % tuple(row) for row in results]
     else:
         return False
 

--- a/tkp/db/sql/statements/batch
+++ b/tkp/db/sql/statements/batch
@@ -1,25 +1,6 @@
 #
 # ordered list of sql files that should be imported
 #
-tables/version.sql
-tables/frequencyband.sql
-tables/dataset.sql
-tables/skyregion.sql
-tables/image.sql
-tables/extractedsource.sql
-tables/runningcatalog.sql
-tables/monitor.sql
-tables/assocxtrsource.sql
-tables/assocskyrgn.sql
-tables/runningcatalog_flux.sql
-tables/temprunningcatalog.sql
-tables/node.sql
-tables/newsource.sql
-tables/rejectreason.sql
-tables/rejection.sql
-tables/config.sql
-tables/add.fk.extractedsource.sql
-#
 #system functions
 #
 functions/degrad.sql
@@ -37,6 +18,7 @@ procedures/BuildNodes.sql
 # initialisation
 #
 init/tables.sql
+init/rejectreasons.sql
 #
 # views
 #

--- a/tkp/db/sql/statements/init/rejectreasons.sql
+++ b/tkp/db/sql/statements/init/rejectreasons.sql
@@ -1,0 +1,4 @@
+INSERT INTO rejectreason VALUES (0, 'RMS invalid');
+INSERT INTO rejectreason VALUES (1, 'beam invalid');
+INSERT INTO rejectreason VALUES (2, 'bright source near');
+INSERT INTO rejectreason VALUES (3, 'tau_time invalid');

--- a/tkp/db/sql/statements/init/tables.sql
+++ b/tkp/db/sql/statements/init/tables.sql
@@ -6,5 +6,8 @@ CALL BuildFrequencyBands();
 SELECT BuildFrequencyBands();
 {% endifdb %}
 
+
+
+
 --CALL BuildNodes(-90,90, FALSE);
 

--- a/tkp/management.py
+++ b/tkp/management.py
@@ -238,27 +238,6 @@ def init_db(options):
     else:
         dbconfig = get_database_config(None, apply=False)
 
-    if 'engine' not in dbconfig or not dbconfig['engine']:
-        dbconfig['engine'] = 'postgresql'
-
-    if 'port' not in dbconfig or not dbconfig['port']:
-        if dbconfig['engine'] == 'monetdb':
-            dbconfig['port'] = 50000
-        else:
-            dbconfig['port'] = 5432
-
-    if 'database' not in dbconfig or not dbconfig['database']:
-        dbconfig['database'] = getpass.getuser()
-
-    if 'user' not in dbconfig or not dbconfig['user']:
-        dbconfig['user'] = dbconfig['database']
-
-    if 'password' not in dbconfig or not dbconfig['password']:
-        dbconfig['password'] = dbconfig['user']
-
-    if 'host' not in dbconfig or not dbconfig['host']:
-        dbconfig['host'] = 'localhost'
-
     dbconfig['yes'] = options.yes
     dbconfig['destroy'] = options.destroy
 

--- a/tkp/testutil/db_queries.py
+++ b/tkp/testutil/db_queries.py
@@ -17,7 +17,7 @@ def dataset_images(dataset_id, database=None):
 def convert_to_cartesian(conn, ra, decl):
     """Returns tuple (x,y,z)"""
     qry = """SELECT x,y,z FROM cartesian(%s, %s)"""
-    curs = conn.cursor()
+    curs = conn.connection.cursor()
     curs.execute(qry, (ra, decl))
     return curs.fetchone()
 

--- a/tkp/testutil/db_subs.py
+++ b/tkp/testutil/db_subs.py
@@ -406,7 +406,7 @@ def get_newsources_for_dataset(dsid):
         AND ax.xtrsrc = ex.id
         AND tr.previous_limits_image = limits_image.id
     """
-    cursor = Database().connection.cursor()
+    cursor = Database().cursor
     cursor.execute(qry, {'dsid':dsid})
     newsource_rows_for_dataset = get_db_rows_as_dicts(cursor)
     return newsource_rows_for_dataset
@@ -463,7 +463,7 @@ WHERE rc.dataset = %(dataset_id)s
   AND eta_int >= %(eta_min)s
   AND v_int >= %(v_min)s
 """
-    cursor = tkp.db.Database().connection.cursor()
+    cursor = tkp.db.Database().cursor
     cursor.execute(query, {'dataset_id': dataset_id,
                            'eta_min':eta_min,
                            'v_min':v_min,


### PR DESCRIPTION
This adds a SQLALchemy backend to TraP. I tried to keep the changes as minimal as possible.

basically it sums down to:
 * add SQLAlchemy dependencies, switch to pymonetdb
 * Add a SQLAlchemy declarative model (`tkp.db.model`)
 * Add backwards compatibility code
 * Use declarative model to initialize the tables
 * Use backwards compatibility code to initialize functions and others
 * Minimal rewrite of database configuration logic

There is more work to be done, but this keeps the pipeline working without to much changes, and it is a nice new foundation for future code and a internal/external TraP database API. Actually from the outside nothing changed, but you can now also use `tkp.db.model` do query the database.

