### PR TITLE
switch to python-casacore

### DIFF
--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -35,8 +35,8 @@ MOCK_MODULES = [#'numpy', 'numpy.ma',
                 #'scipy', 'scipy.integrate', 'scipy.optimize',
                 #'scipy.special', 'scipy.constants','scipy.interpolate',
                 'pyfits', 'pywcs',
-                'pyrap', 'pyrap.measures', 'pyrap.tables','pyrap.images',
-                'pyrap.quanta',
+                'casacore', 'casacore.measures', 'casacore.tables','casacore.images',
+                'casacore.quanta',
                 ]
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
@@ -286,13 +286,13 @@ nitpick_ignore = [
     ("py:obj", "dict/list/tuple"),
     ("py:obj", "3-tuple of float"),
     ("py:obj", "3-tuple"),
-    ("py:obj", "pyrap.images.image"),
-    ("py:obj", "pyrap.tables.table"),
+    ("py:obj", "casacore.images.image"),
+    ("py:obj", "casacore.tables.table"),
     ("py:obj", "list of (RA, Dec) tuples"),
     ("py:obj", "list of tuples"),
     ("py:obj", "ExtractedSourceTuple"),
     ("py:obj", "list of MockSource"),
-    ("py:obj", "pyrap measure"),
+    ("py:obj", "casacore measure"),
     ("py:obj", "lambda"),
     # These result from incorrect docstrings, should really be fixed
     # but we'll just suppress the errors for now.

--- a/documentation/getstart/casacore-measures-data.rst
+++ b/documentation/getstart/casacore-measures-data.rst
@@ -19,7 +19,7 @@ your observation. A simple Python script can be used to check::
 
   $ cat check_ephemeris.py
   import sys
-  from  pyrap.measures import measures
+  from casacore.measures import measures
   dm = measures()
   dm.do_frame(dm.epoch('UTC', sys.argv[1]))
   dm.separation(dm.direction('SUN'), dm.direction('SUN'))

--- a/documentation/getstart/installation.rst
+++ b/documentation/getstart/installation.rst
@@ -84,8 +84,8 @@ In addition to the above, to run the TraP you will need:
 
 * `SciPy <http://www.scipy.org/>`_ (at least version 0.7.0)
 * `python-dateutil <http://labix.org/python-dateutil>`_ (at least version 1.4.1)
-* `pyrap <https://code.google.com/p/pyrap/>`_ and
-  `casacore <https://code.google.com/p/casacore/>`_ (including measures data)
+* `python-casacore <https://github.com/casacore/python-casacore/>`_ and
+  `casacore <https://github.com/casacore/casacore/>`_ (including measures data)
 
 To work with the pipeline database, you will need at least one of:
 
@@ -100,10 +100,11 @@ Most of these dependencies should be easily satisfied by operating
 system-level package management or through the `Python Package Index
 <https://pypi.python.org/pypi>`_, and we strongly suggest you take advantage
 of that convenience rather than building everything from source. The most
-notable exceptions are pyrap and casacore: these are not commonly packaged in
-mainstream distributions. They can be compiled from source, or users of
-Ubuntu-based distributions might find the `SKA South Africa Launchpad page
-<https://launchpad.net/~ska-sa>`_ useful.
+notable exceptions are is casacore: this are not commonly packaged in
+mainstream distributions. Casacore can be compiled from source, or users of
+Ubuntu-based distributions might find the `Radio Astronomy Ubuntu Personal
+Packaging Archive
+<https://launchpad.net/~radio-astro/+archive/ubuntu/main>`_ useful.
 
 .. warning::
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pyfits>=2.3.1
 python-dateutil>=1.4.1
 pytz
 pywcs
-#pyrap>=1.1.0  # not available on pip
+python-casacore
 
 ## If you require distributed processing:
 #celery>=3.1.11

--- a/tests/test_accessors/test_detection.py
+++ b/tests/test_accessors/test_detection.py
@@ -39,7 +39,7 @@ class TestAutodetect(unittest.TestCase):
 
     @requires_data(hdf5file)
     def test_ishdf5(self):
-        # TODO: disable this for now, since pyrap can't parse LOFAR hdf5
+        # TODO: disable this for now, since casacore can't parse LOFAR hdf5
         #self.assertTrue(islofarhdf5(hdf5file))
         self.assertFalse(isfits(hdf5file))
         self.assertFalse(iscasa(hdf5file))

--- a/tests/test_quality/test_brightsource.py
+++ b/tests/test_quality/test_brightsource.py
@@ -1,6 +1,5 @@
-import os
 from math import degrees
-from pyrap.measures import measures
+from casacore.measures import measures
 
 import unittest
 import datetime

--- a/tests/test_utility/test_coordinates.py
+++ b/tests/test_utility/test_coordinates.py
@@ -5,7 +5,7 @@ Test functions used for manipulating coordinates in the TKP pipeline.
 import pytz
 
 import unittest
-from pyrap.measures import measures
+from casacore.measures import measures
 
 import datetime
 from tkp.utility import coordinates

--- a/tkp/accessors/amicasaimage.py
+++ b/tkp/accessors/amicasaimage.py
@@ -2,15 +2,14 @@
 This module implements the CASA kat7 data container format.
 """
 import logging
-from pyrap.tables import table as pyrap_table
 from tkp.accessors.casaimage import CasaImage
-from tkp.utility.coordinates import mjd2datetime
+
 
 logger = logging.getLogger(__name__)
 
 class AmiCasaImage(CasaImage):
     """
-    Use pyrap to pull image data out of a CASA table as produced by AMI-LA.
+    Use casacore to pull image data out of a CASA table as produced by AMI-LA.
 
     Note that AMI-LA does not currently include image duration in its headers,
     so we use a placeholder value of 1.
@@ -28,4 +27,4 @@ class AmiCasaImage(CasaImage):
     def __init__(self, url, plane=0, beam=None):
         super(AmiCasaImage, self).__init__(url, plane, beam)
         self.taustart_ts = self.parse_taustartts()
-        self.tau_time = 1 # Placeholder value until properly implemented
+        self.tau_time = 1  # Placeholder value until properly implemented

--- a/tkp/accessors/casaimage.py
+++ b/tkp/accessors/casaimage.py
@@ -1,6 +1,6 @@
 import logging
 import warnings
-from pyrap.tables import table as pyrap_table
+from casacore.tables import table as casacore_table
 from math import degrees
 from tkp.accessors.dataaccessor import DataAccessor
 from tkp.utility.coordinates import WCS
@@ -22,7 +22,7 @@ class CasaImage(DataAccessor):
     def __init__(self, url, plane=0, beam=None):
         super(CasaImage, self).__init__()
         self.url = url
-        self.table = pyrap_table(self.url.encode(), ack=False)
+        self.table = casacore_table(self.url.encode(), ack=False)
         self.data = self.parse_data(plane)
         self.wcs = self.parse_coordinates()
         self.centre_ra, self.centre_decl = self.parse_phase_centre()
@@ -130,7 +130,7 @@ class CasaImage(DataAccessor):
         Find all the unique values in a particular column of a CASA table.
 
         Arguments:
-          - table:       ``pyrap.tables.table``
+          - table:       ``casacore.tables.table``
           - column_name: ``str``
 
         Returns:

--- a/tkp/accessors/detection.py
+++ b/tkp/accessors/detection.py
@@ -2,8 +2,8 @@ import os.path
 import pyfits
 import logging
 from collections import namedtuple
-from pyrap.tables import table as pyrap_table
-from pyrap.images import image as pyrap_image
+from casacore.tables import table as casacore_table
+from casacore.images import image as casacore_image
 from tkp.accessors.lofarcasaimage import LofarCasaImage
 from tkp.accessors.lofarhdf5image import LofarHdf5Image
 from tkp.accessors.fitsimage import FitsImage
@@ -58,7 +58,7 @@ def iscasa(filename):
             logger.debug("%s doesn't contain %s" % (filename, file_))
             return False
     try:
-        table = pyrap_table(filename.encode(), ack=False)
+        table = casacore_table(filename.encode(), ack=False)
         table.close()
     except RuntimeError as e:
         logger.debug("directory looks casacore, but cannot open: %s" % str(e))
@@ -73,7 +73,7 @@ def islofarhdf5(filename):
     if filename[-2:].lower() != 'h5':
         return False
     try:
-        pyrap_image(filename)
+        casacore_image(filename)
     except RuntimeError:
         return False
     return True
@@ -101,7 +101,7 @@ def casa_detect(filename):
     Checks for known CASA table types where we expect additional metadata.
     If the telescope is unknown we return nothing.
     """
-    table = pyrap_table(filename.encode(), ack=False)
+    table = casacore_table(filename.encode(), ack=False)
     telescope = table.getkeyword('coords')['telescope']
     return casa_telescope_keyword_mapping.get(telescope, None)
 

--- a/tkp/accessors/kat7casaimage.py
+++ b/tkp/accessors/kat7casaimage.py
@@ -2,7 +2,7 @@
 This module implements the CASA kat7 data container format.
 """
 import logging
-from pyrap.tables import table as pyrap_table
+from casacore.tables import table as casacore_table
 from tkp.accessors.casaimage import CasaImage
 
 
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 class Kat7CasaImage(CasaImage):
     """
-    Use pyrap to pull image data out of a CASA table as produced by KAT-7.
+    Use casacore to pull image data out of a CASA table as produced by KAT-7.
 
     Note that KAT-7 does not currently include image duration in its headers,
     so we use a placeholder value of 1.

--- a/tkp/accessors/lofarcasaimage.py
+++ b/tkp/accessors/lofarcasaimage.py
@@ -8,7 +8,7 @@ import logging
 import warnings
 import numpy
 import datetime
-from pyrap.tables import table as pyrap_table
+from casacore.tables import table as casacore_table
 from tkp.accessors.casaimage import CasaImage
 from tkp.accessors.lofaraccessor import LofarAccessor
 from tkp.utility.coordinates import julian2unix
@@ -29,7 +29,7 @@ subtable_names = (
 
 class LofarCasaImage(CasaImage, LofarAccessor):
     """
-    Use pyrap to pull image data out of an Casa table.
+    Use casacore to pull image data out of an Casa table.
 
     This accessor assumes the casatable contains the values described in the
     CASA Image description for LOFAR. 0.03.00.
@@ -58,14 +58,14 @@ class LofarCasaImage(CasaImage, LofarAccessor):
     def open_subtables(self):
         """open all subtables defined in the LOFAR format
         args:
-            table: a pyrap table handler to a LOFAR CASA table
+            table: a casacore table handler to a LOFAR CASA table
         returns:
             a dict containing all LOFAR CASA subtables
         """
         subtables = {}
         for subtable in subtable_names:
             subtable_location = self.table.getkeyword("ATTRGROUPS")[subtable]
-            subtables[subtable] = pyrap_table(subtable_location, ack=False)
+            subtables[subtable] = casacore_table(subtable_location, ack=False)
         return subtables
 
 

--- a/tkp/inject.py
+++ b/tkp/inject.py
@@ -8,13 +8,13 @@ import argparse
 from ConfigParser import SafeConfigParser
 from tkp.config import parse_to_dict
 import pyfits
-from pyrap.tables import table as pyrap_table
+from casacore.tables import table as casacore_table
 import tkp.accessors.detection
-from tkp.accessors import FitsImage, LofarFitsImage, LofarCasaImage
+from tkp.accessors import FitsImage, LofarCasaImage
 
 import logging
 
-logger=logging.getLogger()
+logger = logging.getLogger()
 
 type_mapping = {
     str: 'getString',
@@ -77,9 +77,9 @@ def modify_fits_headers(parset, fits_file, overwrite):
     fits_file.close()
 
 def modify_lofarcasa_tau_time(parset, casa_file):
-    table = pyrap_table(casa_file, ack=False)
+    table = casacore_table(casa_file, ack=False)
     origin_location = table.getkeyword("ATTRGROUPS")['LOFAR_ORIGIN']
-    origin_table = pyrap_table(origin_location, ack=False, readonly=False)
+    origin_table = casacore_table(origin_location, ack=False, readonly=False)
 
     for parset_field, value in parset.items():
         if parset_field == 'tau_time':

--- a/tkp/quality/brightsource.py
+++ b/tkp/quality/brightsource.py
@@ -1,9 +1,9 @@
 import sys
 import logging
 import warnings
-import pyrap.quanta as qa
+import casacore.quanta as qa
 from io import BytesIO
-from pyrap.measures import measures
+from casacore.measures import measures
 from tkp.utility.coordinates import unix2julian
 from tkp.utility.redirect_stream import redirect_stream
 
@@ -25,15 +25,15 @@ def check_for_valid_ephemeris(measures):
     ``measures`` should already have a valid reference frame.
     """
     # Note that we need to catch and parse the standard error produced by
-    # pyrap: there doesn't seem to be any other way of figuring this out.
-    pyrap_stderr = BytesIO()
-    with redirect_stream(sys.__stderr__, pyrap_stderr):
+    # casacore: there doesn't seem to be any other way of figuring this out.
+    casacore_stderr = BytesIO()
+    with redirect_stream(sys.__stderr__, casacore_stderr):
         # We assume the ephemeris is valid if it has position of the sun.
         measures.separation(
             measures.direction("SUN"), measures.direction("SUN")
         )
-    if "WARN" in pyrap_stderr.getvalue():
-        # pyrap sends a warning to stderr if the ephemeris is invalid
+    if "WARN" in casacore_stderr.getvalue():
+        # casacore sends a warning to stderr if the ephemeris is invalid
         return False
     else:
         return True
@@ -50,7 +50,7 @@ def is_bright_source_near(accessor, distance=20):
     """
 
     #TODO: this function should be split up and tested more atomically
-    # The measures object is our interface to pyrap
+    # The measures object is our interface to casacore
     m = measures()
 
     # First, you need to set the reference frame -- ie, the time

--- a/tkp/steps/persistence.py
+++ b/tkp/steps/persistence.py
@@ -7,7 +7,7 @@ import logging
 import warnings
 from tempfile import NamedTemporaryFile
 
-from pyrap.images import image as pyrap_image
+from casacore.images import image as casacore_image
 
 import tkp.accessors
 from tkp.db.database import Database
@@ -40,7 +40,7 @@ def image_to_mongodb(filename, hostname, port, db):
             # is in FITS or CASA format.
             # temp_fits_file is removed automatically when closed.
             temp_fits_file = NamedTemporaryFile()
-            i = pyrap_image(filename)
+            i = casacore_image(filename)
             i.tofits(temp_fits_file.name)
             new_file = gfs.new_file(filename=filename)
             with open(temp_fits_file.name, "r") as f:

--- a/tkp/utility/coordinates.py
+++ b/tkp/utility/coordinates.py
@@ -11,8 +11,8 @@ import logging
 import datetime
 import pytz
 
-from pyrap.measures import measures
-from pyrap.quanta import quantity
+from casacore.measures import measures
+from casacore.quanta import quantity
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +59,7 @@ def mjd2datetime(mjd):
     """
     Convert a Modified Julian Date to datetime via 'unix time' representation.
 
-    NB 'unix time' is defined by the casacore/pyrap package.
+    NB 'unix time' is defined by the casacore/casacore package.
     """
     q = quantity("%sd" % mjd)
     return datetime.datetime.fromtimestamp(q.to_unix_time())
@@ -72,7 +72,7 @@ def mjd2lst(mjd, position=None):
     reference position of CS002.
 
     mjd -- Modified Julian Date (float, in days)
-    position -- Position (pyrap measure)
+    position -- Position (casacore measure)
     """
     dm = measures()
     position = position or dm.position(
@@ -90,7 +90,7 @@ def mjds2lst(mjds, position=None):
 
     Args:
         mjds (float):Modified Julian Date (in seconds)
-        position (pyrap measure): Position for LST calcs
+        position (casacore measure): Position for LST calcs
     """
     return mjd2lst(mjds/SECONDS_IN_DAY, position)
 
@@ -103,7 +103,7 @@ def jd2lst(jd, position=None):
 
     Args:
         jd (float): Julian Date
-        position (pyrap measure): Position for LST calcs.
+        position (casacore measure): Position for LST calcs.
     """
     return mjd2lst(jd - 2400000.5, position)
 

--- a/tkp/utility/fits.py
+++ b/tkp/utility/fits.py
@@ -2,9 +2,9 @@ import os
 import math
 import shutil
 
-import pyrap
-import pyrap.images
-import pyrap.tables
+import casacore
+import casacore.images
+import casacore.tables
 import pyfits
 
 import datetime
@@ -42,9 +42,9 @@ def convert(casa_image, ms, fits_filename=None):
     """Convert a CASA image to FITS, taking care of header keywords
 
     :argument casa_image: CASA image
-    :type casa_image: pyrap.images.image
+    :type casa_image: casacore.images.image
     :argument ms: CASA measurement set
-    :type ms: pyrap.tables.table
+    :type ms: casacore.tables.table
 
     :keyword fits_filename: FITS output filename
     :type fits_filename: str
@@ -62,21 +62,21 @@ def convert(casa_image, ms, fits_filename=None):
     # but I'm not sure how correct the coordinate conversion
     # would be.
     # Currently using the easy way
-    image = pyrap.images.image(casa_image)
+    image = casacore.images.image(casa_image)
     image.tofits(fits_filename)
     hdulist = pyfits.open(fits_filename, mode='update')
     header = hdulist[0].header
     # Obtain header info from original MS
-    t0 = pyrap.tables.table(ms, ack=False)
+    t0 = casacore.tables.table(ms, ack=False)
     header.update('OBS-ID', t0.getcol('OBSERVATION_ID')[0])
 
-    t = pyrap.tables.table(t0.getkeyword('SPECTRAL_WINDOW'), ack=False)
+    t = casacore.tables.table(t0.getkeyword('SPECTRAL_WINDOW'), ack=False)
     header.update('SUBBAND', t.getcol('NAME')[0])
     header.update('REFFREQ', t.getcol('REF_FREQUENCY')[0])
     header.update('BANDWIDT', t.getcol('TOTAL_BANDWIDTH')[0])
     header.update('FREQUNIT', 'MHz')
 
-    t = pyrap.tables.table(t0.getkeyword('FIELD'), ack=False)
+    t = casacore.tables.table(t0.getkeyword('FIELD'), ack=False)
     phasedir = t.getcol('PHASE_DIR')
     phase_ra = phasedir[0][0][0] * 180 / math.pi
     if phase_ra < 0:
@@ -103,7 +103,7 @@ def convert(casa_image, ms, fits_filename=None):
     header.update('MID_UTC', mid_time.strftime("%Y-%m-%dT%H:%M:%S"),
                   "Mid time of observation")
 
-    t = pyrap.tables.table(t0.getkeyword('OBSERVATION'), ack=False)
+    t = casacore.tables.table(t0.getkeyword('OBSERVATION'), ack=False)
     header.update('OBSERVER', t.getcol('OBSERVER')[0])
     header.update('TELESCOP', t.getcol('TELESCOPE_NAME')[0])
 


### PR DESCRIPTION
as expected python-casacore seems to be a dropin replacement for pyrap.

python-casacore is pip installable, simplifying installation instructions a bit.