### PR TITLE
vacuum before _flag_many_to_many_tempruncat

### DIFF
--- a/tkp/db/associations.py
+++ b/tkp/db/associations.py
@@ -848,6 +848,19 @@ UPDATE temprunningcatalog
                   AND t2.xtrsrc = temprunningcatalog.xtrsrc
               )
 """
+
+    database = tkp.db.Database()
+    if database.engine == "postgresql":
+        from psycopg2.extensions import (ISOLATION_LEVEL_AUTOCOMMIT,
+                                            ISOLATION_LEVEL_READ_COMMITTED)
+        # disable autocommit since can't vacuum in transaction
+        connection = database.connection
+        connection.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+        cursor = connection.cursor()
+        cursor.execute("VACUUM ANALYZE temprunningcatalog")
+        # reset settings
+        connection.set_isolation_level(ISOLATION_LEVEL_READ_COMMITTED)
+
     tkp.db.execute(query, commit=True)
 
 

--- a/tkp/db/associations.py
+++ b/tkp/db/associations.py
@@ -39,8 +39,16 @@ def associate_extracted_sources(image_id, deRuiter_r, new_source_sigma_margin):
     #| Here we process (flag) the many-to-many associations.|
     #+------------------------------------------------------+
     database = tkp.db.Database()
-    if database.engine == "postgresql":
-        vacuum_temprunningcatalog()
+
+    # Since the _flag_many_to_many_tempruncat uses the temprunningcatalog table
+    # as a temporary use space the table will receive many writes and updates.
+    # On postgresql for speed up reasons rows are not directly deleted, but
+    # marked for deletion and eventually deleted by an auto vacuum process.
+    # Because of the nested complexity of this query it may happen the
+    # computational complexity of the query explodes, resulting in massive
+    # slowdowns. To make sure the temprunningcatalog table doesn't contain dead
+    # rows we force a manual vacuum here.
+    database.vacuum('temprunningcatalog')
 
     # _process_many_to_many()
     _flag_many_to_many_tempruncat()


### PR DESCRIPTION
Vacuum before running the _flag_many_to_many_tempruncat() query. 
(Addresses #432)
Can't really test this, so no tests.

When we find more places where it is a good idea to execute a vacuum I'll move this to `tkp.db`, but for now I leave it here.