### PR TITLE
Use `with` contexts to encourage closing image files.

### DIFF
--- a/tkp/accessors/detection.py
+++ b/tkp/accessors/detection.py
@@ -42,7 +42,8 @@ def isfits(filename):
     if filename[-4:].lower() != 'fits':
         return False
     try:
-        pyfits.open(filename)
+        with pyfits.open(filename):
+            pass
     except IOError:
         return False
     return True
@@ -86,8 +87,8 @@ def fits_detect(filename):
     Checks for known FITS image types where we expect additional metadata.
     If the telescope is unknown we default to a regular FitsImage.
     """
-    hdu = pyfits.open(filename)
-    hdr = hdu[0].header
+    with pyfits.open(filename) as hdulist:
+        hdr = hdulist[0].header
     for fits_test in fits_type_mapping:
         if fits_test.test(hdr):
             return fits_test.accessor

--- a/tkp/accessors/fitsimage.py
+++ b/tkp/accessors/fitsimage.py
@@ -44,8 +44,8 @@ class FitsImage(DataAccessor):
             self.telescope = self.header['TELESCOP']
 
     def _get_header(self, hdu_index):
-        hdulist = pyfits.open(self.url)
-        hdu = hdulist[hdu_index]
+        with pyfits.open(self.url) as hdulist:
+            hdu = hdulist[hdu_index]
         return hdu.header.copy()
 
 
@@ -60,8 +60,9 @@ class FitsImage(DataAccessor):
         before viewing the array with RO.DS9, saving to a FITS file,
         etc.
         """
-        hdu = pyfits.open(self.url)[hdu_index]
-        data = numpy.float64(hdu.data.squeeze())
+        with pyfits.open(self.url) as hdulist:
+            hdu = hdulist[hdu_index]
+            data = numpy.float64(hdu.data.squeeze())
         if plane is not None and len(data.shape) > 2:
             data = data[plane].squeeze()
         n_dim = len(data.shape)

--- a/tkp/testutil/decorators.py
+++ b/tkp/testutil/decorators.py
@@ -53,3 +53,11 @@ def requires_test_db_managed():
         return lambda func: func
     return unittest.skip("DB management tests disabled, TKP_TESTDBMANAGEMENT"
                          " not set")
+
+def high_ram_requirements():
+    """
+    Used to disable tests that break Travis due to out-of-memory issues.
+    """
+    if os.environ.get("TRAVIS", False):
+        return unittest.skip("High-ram requirement unit-tests disabled on Travis")
+    return lambda func: func

--- a/tkp/utility/fits.py
+++ b/tkp/utility/fits.py
@@ -141,9 +141,9 @@ def combine(fitsfiles, outputfile, method="average"):
     header0.update('orig0', os.path.basename(fitsfiles[0]),
                    'original fitsfile')
     for i, filename in enumerate(fitsfiles[1:]):
-        hdulist = pyfits.open(filename)
-        header = hdulist[0].header
-        data += hdulist[0].data
+        with pyfits.open(filename) as hdulist:
+            header = hdulist[0].header
+            data += hdulist[0].data
         freqs.append(header['reffreq'])
         header0.update(
             'orig%d' % (i + 1), os.path.basename(filename),
@@ -171,3 +171,5 @@ def combine(fitsfiles, outputfile, method="average"):
     hdu.header = header0
     hdulist = pyfits.HDUList([hdu])
     hdulist.writeto(outputfile)
+    hdulist.close()
+    hdulist0.close()


### PR DESCRIPTION
Hopefully this might improve RAM usage, and prevent Travis failing.