### PR TITLE
Vacuum before flag_many_to_many to prevent Postgres slowdown.

### DIFF
--- a/tkp/db/associations.py
+++ b/tkp/db/associations.py
@@ -38,6 +38,18 @@ def associate_extracted_sources(image_id, deRuiter_r, new_source_sigma_margin):
     #+------------------------------------------------------+
     #| Here we process (flag) the many-to-many associations.|
     #+------------------------------------------------------+
+    database = tkp.db.Database()
+
+    # Since the _flag_many_to_many_tempruncat uses the temprunningcatalog table
+    # as a temporary use space the table will receive many writes and updates.
+    # On postgresql for speed up reasons rows are not directly deleted, but
+    # marked for deletion and eventually deleted by an auto vacuum process.
+    # Because of the nested complexity of this query it may happen the
+    # computational complexity of the query explodes, resulting in massive
+    # slowdowns. To make sure the temprunningcatalog table doesn't contain dead
+    # rows we force a manual vacuum here.
+    database.vacuum('temprunningcatalog')
+
     # _process_many_to_many()
     _flag_many_to_many_tempruncat()
     #+------------------------------------------------------+
@@ -102,6 +114,8 @@ def associate_extracted_sources(image_id, deRuiter_r, new_source_sigma_margin):
 # Subroutines...
 # Here be SQL dragons.
 ##############################################################################
+
+
 def _delete_bad_blind_extractions(image_id):
     """Remove blind extractions centred outside designated extract region.
 
@@ -848,6 +862,7 @@ UPDATE temprunningcatalog
                   AND t2.xtrsrc = temprunningcatalog.xtrsrc
               )
 """
+
     tkp.db.execute(query, commit=True)
 
 


### PR DESCRIPTION
(Closes issue #432)

This is a rebased and squashed version of #436, to tidy and pull in the new Travis setup.