### PR TITLE
Add user-parameter to control hard-limit on association radius

### DIFF
--- a/documentation/userref/config/job_params_cfg.rst
+++ b/documentation/userref/config/job_params_cfg.rst
@@ -122,6 +122,14 @@ source-association.
    Float. Maximum DeRuiter radius for two sources to be considered candidates
    for association.
 
+``beamwidths_limit``
+   Float. Maximum separation for two sources to be considered candidates for
+   association, as a multiple of the restoring-beam semimajor-axis length.
+   Default is 1.0, which was the fixed default prior to TraP release 2.1.
+   It may be necessary to use a larger number if your data has large
+   systematic position errors, i.e. if the sources 'jitter' between images,
+   but note that using a large value can cause slowdown of database operations.
+
 .. _job_params_transient_search:
 
 ``transient_search`` Section

--- a/tests/test_database/test_fluxes.py
+++ b/tests/test_database/test_fluxes.py
@@ -7,10 +7,6 @@ from tkp.testutil import db_subs
 from tkp.testutil import db_queries
 from tkp.testutil.decorators import requires_database
 
-# Use a default argument value for convenience
-from functools import partial
-associate_extracted_sources = partial(associate_extracted_sources,
-                                      new_source_sigma_margin=3)
 
 class TestOne2OneFlux(unittest.TestCase):
     """
@@ -215,7 +211,7 @@ class TestMany2OneFlux(unittest.TestCase):
             ))
 
         dbgen.insert_extracted_sources(image1.id, img1_srclist, 'blind')
-        associate_extracted_sources(image1.id, deRuiter_r = 3.717)
+        associate_extracted_sources(image1.id, deRuiter_r=3.717)
 
         # image 2
         image2 = tkp.db.Image(database=self.database, dataset=dataset, data=im_params[1])
@@ -229,7 +225,7 @@ class TestMany2OneFlux(unittest.TestCase):
             ))
 
         dbgen.insert_extracted_sources(image2.id, img2_srclist, 'blind')
-        associate_extracted_sources(image2.id, deRuiter_r = 3.717)
+        associate_extracted_sources(image2.id, deRuiter_r=3.717)
 
         # Manually compose the lists of sources we expect to see associated
         # into runningcatalog entries:
@@ -340,14 +336,14 @@ class TestMany2Many(unittest.TestCase):
                               data=im_params[0])
         dbgen.insert_extracted_sources(
             image1.id, [eastern_src,western_src], 'blind')
-        associate_extracted_sources(image1.id, deRuiter_r = 3.717)
+        associate_extracted_sources(image1.id, deRuiter_r=3.717)
 
         # image 2
         image2 = tkp.db.Image(database=self.database, dataset=dataset,
                               data=im_params[1])
         dbgen.insert_extracted_sources(
             image2.id, [northern_source, southern_source], 'blind')
-        associate_extracted_sources(image2.id, deRuiter_r = 3.717)
+        associate_extracted_sources(image2.id, deRuiter_r=3.717)
 
         # Manually compose the lists of sources we expect to see associated
         # into runningcatalog entries:
@@ -444,14 +440,14 @@ class TestMany2Many(unittest.TestCase):
                               data=im_params[0])
         dbgen.insert_extracted_sources(
             image1.id, [eastern_src,western_src], 'blind')
-        associate_extracted_sources(image1.id, deRuiter_r = 3.717)
+        associate_extracted_sources(image1.id, deRuiter_r=3.717)
 
         # image 2
         image2 = tkp.db.Image(database=self.database, dataset=dataset,
                               data=im_params[1])
         dbgen.insert_extracted_sources(
             image2.id, [northern_source, southern_source], 'blind')
-        associate_extracted_sources(image2.id, deRuiter_r = 3.717)
+        associate_extracted_sources(image2.id, deRuiter_r=3.717)
 
         # Manually compose the lists of sources we expect to see associated
         # into runningcatalog entries:

--- a/tkp/config/job_template/job_params.cfg
+++ b/tkp/config/job_template/job_params.cfg
@@ -31,6 +31,7 @@ ns_sys_err = 10
 
 [association]
 deruiter_radius = 5.68
+beamwidths_limit =  1.0
 
 [transient_search]
 new_source_sigma_margin = 3

--- a/tkp/db/associations.py
+++ b/tkp/db/associations.py
@@ -558,11 +558,11 @@ INSERT INTO temprunningcatalog
              AND x0.image = %(image_id)s
              AND i0.dataset = rc0.dataset
              AND rc0.mon_src = FALSE
-             AND rc0.zone BETWEEN CAST(FLOOR(x0.decl - i0.rb_smaj) as INTEGER)
-                              AND CAST(FLOOR(x0.decl + i0.rb_smaj) as INTEGER)
-             AND rc0.wm_decl BETWEEN x0.decl - i0.rb_smaj
-                                 AND x0.decl + i0.rb_smaj
-             AND rc0.x*x0.x + rc0.y*x0.y + rc0.z*x0.z > cos(radians(i0.rb_smaj))
+             AND rc0.zone BETWEEN CAST(FLOOR(x0.decl - 5 * i0.rb_smaj) as INTEGER)
+                              AND CAST(FLOOR(x0.decl + 5 * i0.rb_smaj) as INTEGER)
+             AND rc0.wm_decl BETWEEN x0.decl - 5 * i0.rb_smaj
+                                 AND x0.decl + 5 * i0.rb_smaj
+             AND rc0.x*x0.x + rc0.y*x0.y + rc0.z*x0.z > cos(radians(5 * i0.rb_smaj))
              AND CASE WHEN rc0.wm_ra < 90 OR rc0.wm_ra > 270
                       THEN SQRT(  (MOD(CAST(rc0.wm_ra + 180 AS NUMERIC(11,8)), 360) - MOD(CAST(x0.ra + 180 AS NUMERIC(11,8)), 360)) * COS(RADIANS((rc0.wm_decl + x0.decl)/2))
                           * (MOD(CAST(rc0.wm_ra + 180 AS NUMERIC(11,8)), 360) - MOD(CAST(x0.ra + 180 AS NUMERIC(11,8)), 360)) * COS(RADIANS((rc0.wm_decl + x0.decl)/2))
@@ -764,13 +764,13 @@ INSERT INTO temprunningcatalog
              AND x0.image = %(image_id)s
              AND i0.dataset = rc0.dataset
              AND rc0.mon_src = FALSE
-             AND rc0.zone BETWEEN CAST(FLOOR(x0.decl - i0.rb_smaj) AS INTEGER)
-                              AND CAST(FLOOR(x0.decl + i0.rb_smaj) AS INTEGER)
-             AND rc0.wm_decl BETWEEN x0.decl - i0.rb_smaj
-                                 AND x0.decl + i0.rb_smaj
-             AND rc0.wm_ra BETWEEN x0.ra - alpha(i0.rb_smaj, x0.decl)
-                               AND x0.ra + alpha(i0.rb_smaj, x0.decl)
-             AND rc0.x * x0.x + rc0.y * x0.y + rc0.z * x0.z > COS(RADIANS(i0.rb_smaj))
+             AND rc0.zone BETWEEN CAST(FLOOR(x0.decl - 5 * i0.rb_smaj) AS INTEGER)
+                              AND CAST(FLOOR(x0.decl + 5 * i0.rb_smaj) AS INTEGER)
+             AND rc0.wm_decl BETWEEN x0.decl - 5 * i0.rb_smaj
+                                 AND x0.decl + 5 * i0.rb_smaj
+             AND rc0.wm_ra BETWEEN x0.ra - alpha(5 * i0.rb_smaj, x0.decl)
+                               AND x0.ra + alpha(5 * i0.rb_smaj, x0.decl)
+             AND rc0.x * x0.x + rc0.y * x0.y + rc0.z * x0.z > COS(RADIANS(5 * i0.rb_smaj))
              AND SQRT(  (rc0.wm_ra - x0.ra) * COS(RADIANS((rc0.wm_decl + x0.decl)/2))
                       * (rc0.wm_ra - x0.ra) * COS(RADIANS((rc0.wm_decl + x0.decl)/2))
                       / (x0.uncertainty_ew * x0.uncertainty_ew + rc0.wm_uncertainty_ew * rc0.wm_uncertainty_ew)

--- a/tkp/db/associations.py
+++ b/tkp/db/associations.py
@@ -9,7 +9,8 @@ import tkp.db
 logger = logging.getLogger(__name__)
 
 
-def associate_extracted_sources(image_id, deRuiter_r, new_source_sigma_margin):
+def associate_extracted_sources(image_id, deRuiter_r, beamwidths_limit=1,
+                                new_source_sigma_margin=3):
     """
     Associate extracted sources with sources detected in the running
     catalog.
@@ -34,7 +35,7 @@ def associate_extracted_sources(image_id, deRuiter_r, new_source_sigma_margin):
     #| many-to-many, many-to-one, one-to-many, one-to-many  |
     #+------------------------------------------------------+
     mw = _check_meridian_wrap(image_id)
-    _insert_temprunningcatalog(image_id, deRuiter_r, mw)
+    _insert_temprunningcatalog(image_id, deRuiter_r, beamwidths_limit, mw)
     #+------------------------------------------------------+
     #| Here we process (flag) the many-to-many associations.|
     #+------------------------------------------------------+
@@ -299,7 +300,8 @@ SELECT CASE WHEN s.centre_ra - alpha(s.xtr_radius, s.centre_decl) < 0 OR
     }
 
 
-def _insert_temprunningcatalog(image_id, deRuiter_r, mw):
+def _insert_temprunningcatalog(image_id, deRuiter_r, beamwidths_limit,
+                               meridian_wrap):
     """Select matched sources
 
     Here we select the extractedsource that have a positional match
@@ -558,11 +560,11 @@ INSERT INTO temprunningcatalog
              AND x0.image = %(image_id)s
              AND i0.dataset = rc0.dataset
              AND rc0.mon_src = FALSE
-             AND rc0.zone BETWEEN CAST(FLOOR(x0.decl - 5 * i0.rb_smaj) as INTEGER)
-                              AND CAST(FLOOR(x0.decl + 5 * i0.rb_smaj) as INTEGER)
-             AND rc0.wm_decl BETWEEN x0.decl - 5 * i0.rb_smaj
-                                 AND x0.decl + 5 * i0.rb_smaj
-             AND rc0.x*x0.x + rc0.y*x0.y + rc0.z*x0.z > cos(radians(5 * i0.rb_smaj))
+             AND rc0.zone BETWEEN CAST(FLOOR(x0.decl - %(beamwidths_limit)s * i0.rb_smaj) as INTEGER)
+                              AND CAST(FLOOR(x0.decl + %(beamwidths_limit)s * i0.rb_smaj) as INTEGER)
+             AND rc0.wm_decl BETWEEN x0.decl - %(beamwidths_limit)s * i0.rb_smaj
+                                 AND x0.decl + %(beamwidths_limit)s * i0.rb_smaj
+             AND rc0.x*x0.x + rc0.y*x0.y + rc0.z*x0.z > cos(radians(%(beamwidths_limit)s * i0.rb_smaj))
              AND CASE WHEN rc0.wm_ra < 90 OR rc0.wm_ra > 270
                       THEN SQRT(  (MOD(CAST(rc0.wm_ra + 180 AS NUMERIC(11,8)), 360) - MOD(CAST(x0.ra + 180 AS NUMERIC(11,8)), 360)) * COS(RADIANS((rc0.wm_decl + x0.decl)/2))
                           * (MOD(CAST(rc0.wm_ra + 180 AS NUMERIC(11,8)), 360) - MOD(CAST(x0.ra + 180 AS NUMERIC(11,8)), 360)) * COS(RADIANS((rc0.wm_decl + x0.decl)/2))
@@ -764,13 +766,13 @@ INSERT INTO temprunningcatalog
              AND x0.image = %(image_id)s
              AND i0.dataset = rc0.dataset
              AND rc0.mon_src = FALSE
-             AND rc0.zone BETWEEN CAST(FLOOR(x0.decl - 5 * i0.rb_smaj) AS INTEGER)
-                              AND CAST(FLOOR(x0.decl + 5 * i0.rb_smaj) AS INTEGER)
-             AND rc0.wm_decl BETWEEN x0.decl - 5 * i0.rb_smaj
-                                 AND x0.decl + 5 * i0.rb_smaj
-             AND rc0.wm_ra BETWEEN x0.ra - alpha(5 * i0.rb_smaj, x0.decl)
-                               AND x0.ra + alpha(5 * i0.rb_smaj, x0.decl)
-             AND rc0.x * x0.x + rc0.y * x0.y + rc0.z * x0.z > COS(RADIANS(5 * i0.rb_smaj))
+             AND rc0.zone BETWEEN CAST(FLOOR(x0.decl - %(beamwidths_limit)s * i0.rb_smaj) AS INTEGER)
+                              AND CAST(FLOOR(x0.decl + %(beamwidths_limit)s * i0.rb_smaj) AS INTEGER)
+             AND rc0.wm_decl BETWEEN x0.decl - %(beamwidths_limit)s * i0.rb_smaj
+                                 AND x0.decl + %(beamwidths_limit)s * i0.rb_smaj
+             AND rc0.wm_ra BETWEEN x0.ra - alpha(%(beamwidths_limit)s * i0.rb_smaj, x0.decl)
+                               AND x0.ra + alpha(%(beamwidths_limit)s * i0.rb_smaj, x0.decl)
+             AND rc0.x * x0.x + rc0.y * x0.y + rc0.z * x0.z > COS(RADIANS(%(beamwidths_limit)s * i0.rb_smaj))
              AND SQRT(  (rc0.wm_ra - x0.ra) * COS(RADIANS((rc0.wm_decl + x0.decl)/2))
                       * (rc0.wm_ra - x0.ra) * COS(RADIANS((rc0.wm_decl + x0.decl)/2))
                       / (x0.uncertainty_ew * x0.uncertainty_ew + rc0.wm_uncertainty_ew * rc0.wm_uncertainty_ew)
@@ -784,11 +786,12 @@ INSERT INTO temprunningcatalog
          AND t0.stokes = rf0.stokes
 """
     #mw = _check_meridian_wrap(conn, image_id)
-    if mw['q_across'] == True:
-        logger.debug("Search across 0/360 meridian: %s" % mw)
+    if meridian_wrap['q_across'] == True:
+        logger.debug("Search across 0/360 meridian: %s" % meridian_wrap)
         query = q_across_ra0
 
-    args = {'image_id': image_id, 'deRuiter': deRuiter_r}
+    args = {'image_id': image_id, 'deRuiter': deRuiter_r,
+            'beamwidths_limit' : beamwidths_limit}
     tkp.db.execute(query, args, commit=True)
 
 

--- a/tkp/db/orm.py
+++ b/tkp/db/orm.py
@@ -498,7 +498,7 @@ class Image(DBObject):
                 tkp.config module
         """
         associate_extracted_sources(self._id, deRuiter_r,
-                                    new_source_sigma_margin)
+                                    new_source_sigma_margin=new_source_sigma_margin)
 
 
 class ExtractedSource(DBObject):

--- a/tkp/main.py
+++ b/tkp/main.py
@@ -61,6 +61,7 @@ def run(job_name, supplied_mon_coords=[]):
     job_config = load_job_config(pipe_config)
     se_parset = job_config.source_extraction
     deruiter_radius = job_config.association.deruiter_radius
+    beamwidths_limit = job_config.association.beamwidths_limit
     new_src_sigma = job_config.transient_search.new_source_sigma_margin
 
     all_images = imp.load_source('images_to_process',
@@ -158,9 +159,9 @@ def run(job_name, supplied_mon_coords=[]):
             logger.info("performing DB operations for image %s" % image.id)
 
             logger.info("performing source association")
-            dbass.associate_extracted_sources(
-                image.id,deRuiter_r=deruiter_radius,
-                new_source_sigma_margin=new_src_sigma)
+            dbass.associate_extracted_sources(image.id,
+                                              deRuiter_r=deruiter_radius,
+                                              new_source_sigma_margin=new_src_sigma)
 
             all_fit_posns, all_fit_ids = steps_ff.get_forced_fit_requests(image)
             if all_fit_posns:


### PR DESCRIPTION
Adds a new job_param to the source_association section, 'beamwidths_limit', e.g. 

    [association]
    deruiter_radius = 5.68
    beamwidths_limit =  1.0

See commit logs for further details. Closes #421.