### PR TITLE
store varmetric values in a table

### DIFF
--- a/tests/test_database/test_alchemy.py
+++ b/tests/test_database/test_alchemy.py
@@ -1,101 +1,16 @@
 import unittest
 import logging
-from datetime import datetime, timedelta
 
-import tkp.db
 import tkp.db.model
+import tkp.db
 import tkp.db.alchemy
 
+from tkp.testutil.alchemy import gen_band, gen_dataset, gen_skyregion, \
+    gen_lightcurve
 
-logging.basicConfig(level=logging.INFO)
+
+logging.basicConfig(level=logging.WARNING)
 logging.getLogger('sqlalchemy.engine').setLevel(logging.WARNING)
-
-
-def gen_band(central=150**6, low=None, high=None):
-    if not low:
-        low = central * .9
-    if not high:
-        high = central * 1.1
-    return tkp.db.model.Frequencyband(freq_low=low, freq_central=central,
-                                      freq_high=high)
-
-
-def gen_dataset(description):
-    return tkp.db.model.Dataset(process_start_ts=datetime.now(),
-                                description=description)
-
-
-def gen_skyregion(dataset):
-    return tkp.db.model.Skyregion(dataset=dataset, centre_ra=1, centre_decl=1,
-                                  xtr_radius=1, x=1, y=1, z=1)
-
-
-def gen_image(band, dataset, skyregion, taustart_ts=None):
-    if not taustart_ts:
-        taustart_ts = datetime.now()
-    return tkp.db.model.Image(band=band, dataset=dataset, skyrgn=skyregion,
-                              freq_eff=2, rb_smin=1, taustart_ts=taustart_ts,
-                              rb_smaj=1, rb_pa=1, deltax=1, deltay=1, rms_qc=0)
-
-
-def gen_extractedsource(image):
-    return tkp.db.model.Extractedsource(zone=1, ra=1, decl=1, uncertainty_ew=1, x=1, y=1,
-                                        z=1, uncertainty_ns=1, ra_err=1, decl_err=1,
-                                        ra_fit_err=1, decl_fit_err=1, ew_sys_err=1,
-                                        ns_sys_err=1, error_radius=1, racosdecl=1,
-                                        det_sigma=1, f_int=0.01, image=image)
-
-
-def gen_runningcatalog(xtrsrc, dataset):
-    return tkp.db.model.Runningcatalog(xtrsrc=xtrsrc, dataset=dataset, datapoints=1,
-                                       zone=1, wm_ra=1., wm_decl=1, wm_uncertainty_ew=1,
-                                       wm_uncertainty_ns=1, avg_ra_err=1, avg_decl_err=1,
-                                       avg_wra=1, avg_wdecl=1, avg_weight_ra=1, avg_weight_decl=1,
-                                       x=1, y=1, z=1)
-
-
-def gen_assocxtrsource(runningcatalog, xtrsrc):
-    return tkp.db.model.Assocxtrsource(runcat=runningcatalog, xtrsrc=xtrsrc,
-                                       type=0, r=0, distance_arcsec=0, v_int=0,
-                                       eta_int=0, f_datapoints=0)
-
-
-def gen_newsource(runcat, xtrsrc, image):
-    return tkp.db.model.Newsource(runcat=runcat, trigger_xtrsrc=xtrsrc,
-                                  newsource_type=1, previous_limits_image=image)
-
-
-def gen_lightcurve(band, dataset, skyregion, datapoints=10):
-    """
-    returns: a list of created SQLAlchemy objects
-    """
-    start = datetime.fromtimestamp(0)
-    ten_sec = timedelta(seconds=10)
-    xtrsrcs = []
-    images = []
-    assocs = []
-    for i in range(datapoints):
-        taustart_ts = start + ten_sec * i
-        image = gen_image(band, dataset, skyregion, taustart_ts)
-
-        if i == 5:
-            image.int = 10
-        images.append(image)
-        xtrsrcs.append(gen_extractedsource(image))
-
-    # now we can make runningcatalog, we use first xtrsrc as trigger src
-    runningcatalog = gen_runningcatalog(xtrsrcs[0], dataset)
-
-    # create the associations. Can't do this directly since the
-    # association table has non nullable columns
-    for xtrsrc in xtrsrcs:
-        assocs.append(gen_assocxtrsource(runningcatalog, xtrsrc))
-
-    newsource = gen_newsource(runningcatalog, xtrsrcs[5], images[4])
-
-    # just return all db objects we created
-    return [dataset, band, skyregion, runningcatalog, newsource] + images + \
-           xtrsrcs + assocs
 
 
 class TestApi(unittest.TestCase):
@@ -150,43 +65,56 @@ class TestApi(unittest.TestCase):
         shouldbe = [1.0, 1.0, 1.0, 1.0, 1, 0.0, 0.0, None, None, 0.01, 0.01]
         self.assertEqual(r, shouldbe)
 
-    def test_transient(self):
-        r = tkp.db.alchemy.transients(self.session, self.dataset1).all()
+    def test_calculate_varmetric(self):
+        r = tkp.db.alchemy.calculate_varmetric(self.session, self.dataset1).all()
         self.assertEqual(len(r), 2)
 
-    def test_transient_region(self):
+    def test_calculate_varmetric_region(self):
         """
         Ra & Decl filtering
         """
-        r = tkp.db.alchemy.transients(self.session, self.dataset1, ra_range=(0, 2),
-                                  decl_range=(0, 2)).all()
+        r = tkp.db.alchemy.calculate_varmetric(self.session, self.dataset1,
+                                               ra_range=(0, 2),
+                                               decl_range=(0, 2)).all()
         self.assertEqual(len(r), 2)
 
-        r = tkp.db.alchemy.transients(self.session, self.dataset1, ra_range=(20, 22),
-                                  decl_range=(20, 22)).all()
+        r = tkp.db.alchemy.calculate_varmetric(self.session, self.dataset1,
+                                               ra_range=(20, 22),
+                                               decl_range=(20, 22)).all()
         self.assertEqual(len(r), 0)
 
-    def test_transient_cutoff(self):
+    def test_calculate_varmetric_cutoff(self):
         """
         V_int & eta_int filtering
         """
-        r = tkp.db.alchemy.transients(self.session, self.dataset1, v_int_min=0,
-                                  eta_int_min=0).all()
+        r = tkp.db.alchemy.calculate_varmetric(self.session, self.dataset1,
+                                               v_int_min=0,
+                                               eta_int_min=0).all()
         self.assertEqual(len(r), 2)
 
-        q = tkp.db.alchemy.transients(self.session, self.dataset1, v_int_min=1000,
-                                  eta_int_min=0)
+        q = tkp.db.alchemy.calculate_varmetric(self.session, self.dataset1,
+                                               v_int_min=1000,
+                                               eta_int_min=0)
         r = q.all()
         self.assertEqual(len(r), 0)
 
-        r = tkp.db.alchemy.transients(self.session, self.dataset1, v_int_min=0,
-                                  eta_int_min=1000).all()
+        r = tkp.db.alchemy.calculate_varmetric(self.session, self.dataset1,
+                                               v_int_min=0,
+                                               eta_int_min=1000).all()
         self.assertEqual(len(r), 0)
 
-    def test_transient_newsource(self):
+    def test_calculate_varmetric_newsource(self):
         """
         Ra & Decl filtering
         """
-        r = tkp.db.alchemy.transients(self.session, self.dataset1,
-                                  new_src_only=True).all()
+        r = tkp.db.alchemy.calculate_varmetric(self.session, self.dataset1,
+                                               new_src_only=True).all()
+        self.assertEqual(len(r), 2)
+
+    def test_store_varmetric(self):
+        q = tkp.db.alchemy.store_varmetric(self.session, self.dataset1)
+        self.session.execute(q)
+        r = self.session.query(tkp.db.model.Varmetric).\
+            join(tkp.db.model.Varmetric.runcat).\
+            filter_by(dataset=self.dataset1).all()
         self.assertEqual(len(r), 2)

--- a/tests/test_steps/test_varmetric.py
+++ b/tests/test_steps/test_varmetric.py
@@ -1,0 +1,38 @@
+import unittest
+import logging
+
+import tkp.db.model
+
+from tkp.testutil.alchemy import gen_band, gen_dataset, gen_skyregion,\
+    gen_lightcurve
+
+import tkp.db
+import tkp.db.alchemy
+
+from tkp.steps.varmetric import execute_store_varmetric
+
+
+logging.basicConfig(level=logging.INFO)
+logging.getLogger('sqlalchemy.engine').setLevel(logging.WARNING)
+
+
+class TestApi(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.db = tkp.db.Database()
+        cls.db.connect()
+
+    def setUp(self):
+        self.session = self.db.Session()
+
+        band = gen_band(central=150**6)
+        self.dataset = gen_dataset('test varmetric step')
+        skyregion = gen_skyregion(self.dataset)
+        lightcurve = gen_lightcurve(band, self.dataset, skyregion)
+        self.session.add_all(lightcurve)
+        self.session.flush()
+        self.session.commit()
+
+    def test_execute_store_varmetric(self):
+        session = self.db.Session()
+        execute_store_varmetric(session=session, dataset_id=self.dataset.id)

--- a/tkp/db/model.py
+++ b/tkp/db/model.py
@@ -294,6 +294,32 @@ class Runningcatalog(Base):
                                     secondary='assocxtrsource',
                                     backref='runningcatalogs')
 
+    varmetric = relationship("Varmetric", uselist=False, backref="runcat")
+
+
+class Varmetric(Base):
+    __tablename__ = 'varmetric'
+
+    id = Column(Integer, primary_key=True)
+
+    runcat_id = Column('runcat', ForeignKey('runningcatalog.id'),
+                       nullable=False, index=True)
+
+    v_int = Column(Double, index=True)
+    eta_int = Column(Double)
+
+    band_id = Column('band', ForeignKey('frequencyband.id'), nullable=False,
+                     index=True)
+    band = relationship('Frequencyband')
+
+    newsource = Column(Integer)
+    sigma_rms_max = Column(Double, index=True)
+    sigma_rms_min = Column(Double, index=True)
+    lightcurve_max = Column(Double, index=True)
+    lightcurve_avg = Column(Double, index=True)
+    lightcurve_median = Column(Double, index=True)
+
+
 class RunningcatalogFlux(Base):
     __tablename__ = 'runningcatalog_flux'
     __table_args__ = (

--- a/tkp/main.py
+++ b/tkp/main.py
@@ -19,6 +19,7 @@ from tkp.steps.misc import (load_job_config, dump_configs_to_logdir,
 from tkp.db.configstore import store_config, fetch_config
 from tkp.steps.persistence import create_dataset, store_images
 import tkp.steps.forced_fitting as steps_ff
+from tkp.steps.varmetric import execute_store_varmetric
 
 
 logger = logging.getLogger(__name__)
@@ -166,3 +167,6 @@ def run(job_name, supplied_mon_coords=[]):
 
 
         dbgen.update_dataset_process_end_ts(dataset_id)
+
+    logger.info("calculating variability metrics")
+    execute_store_varmetric(dataset_id)

--- a/tkp/steps/varmetric.py
+++ b/tkp/steps/varmetric.py
@@ -1,0 +1,22 @@
+from tkp.db.alchemy import store_varmetric
+from tkp.db.model import Dataset
+from tkp.db import Database
+
+
+def execute_store_varmetric(dataset_id, session=None):
+    """
+    Executes the storing varmetric function. Will create a database session
+    if none is supplied
+
+    args:
+        dataset_id: the ID of the dataset for which you want to store the varmetrics
+        session: An optional SQLAlchemy session
+    """
+    if not session:
+        database = Database()
+        session = database.Session()
+
+    dataset = Dataset(id=dataset_id)
+    query = store_varmetric(session, dataset=dataset)
+    session.execute(query)
+    session.commit()

--- a/tkp/testutil/alchemy.py
+++ b/tkp/testutil/alchemy.py
@@ -1,0 +1,89 @@
+from datetime import datetime, timedelta
+import tkp.db
+
+
+def gen_band(central=150**6, low=None, high=None):
+    if not low:
+        low = central * .9
+    if not high:
+        high = central * 1.1
+    return tkp.db.model.Frequencyband(freq_low=low, freq_central=central,
+                                      freq_high=high)
+
+
+def gen_dataset(description):
+    return tkp.db.model.Dataset(process_start_ts=datetime.now(),
+                                description=description)
+
+
+def gen_skyregion(dataset):
+    return tkp.db.model.Skyregion(dataset=dataset, centre_ra=1, centre_decl=1,
+                                  xtr_radius=1, x=1, y=1, z=1)
+
+
+def gen_image(band, dataset, skyregion, taustart_ts=None):
+    if not taustart_ts:
+        taustart_ts = datetime.now()
+    return tkp.db.model.Image(band=band, dataset=dataset, skyrgn=skyregion,
+                              freq_eff=2, rb_smin=1, taustart_ts=taustart_ts,
+                              rb_smaj=1, rb_pa=1, deltax=1, deltay=1, rms_qc=0)
+
+
+def gen_extractedsource(image):
+    return tkp.db.model.Extractedsource(zone=1, ra=1, decl=1, uncertainty_ew=1, x=1, y=1,
+                                        z=1, uncertainty_ns=1, ra_err=1, decl_err=1,
+                                        ra_fit_err=1, decl_fit_err=1, ew_sys_err=1,
+                                        ns_sys_err=1, error_radius=1, racosdecl=1,
+                                        det_sigma=1, f_int=0.01, image=image)
+
+
+def gen_runningcatalog(xtrsrc, dataset):
+    return tkp.db.model.Runningcatalog(xtrsrc=xtrsrc, dataset=dataset, datapoints=1,
+                                       zone=1, wm_ra=1., wm_decl=1, wm_uncertainty_ew=1,
+                                       wm_uncertainty_ns=1, avg_ra_err=1, avg_decl_err=1,
+                                       avg_wra=1, avg_wdecl=1, avg_weight_ra=1, avg_weight_decl=1,
+                                       x=1, y=1, z=1)
+
+
+def gen_assocxtrsource(runningcatalog, xtrsrc):
+    return tkp.db.model.Assocxtrsource(runcat=runningcatalog, xtrsrc=xtrsrc,
+                                       type=0, r=0, distance_arcsec=0, v_int=0,
+                                       eta_int=0, f_datapoints=0)
+
+
+def gen_newsource(runcat, xtrsrc, image):
+    return tkp.db.model.Newsource(runcat=runcat, trigger_xtrsrc=xtrsrc,
+                                  newsource_type=1, previous_limits_image=image)
+
+
+def gen_lightcurve(band, dataset, skyregion, datapoints=10):
+    """
+    returns: a list of created SQLAlchemy objects
+    """
+    start = datetime.fromtimestamp(0)
+    ten_sec = timedelta(seconds=10)
+    xtrsrcs = []
+    images = []
+    assocs = []
+    for i in range(datapoints):
+        taustart_ts = start + ten_sec * i
+        image = gen_image(band, dataset, skyregion, taustart_ts)
+
+        if i == 5:
+            image.int = 10
+        images.append(image)
+        xtrsrcs.append(gen_extractedsource(image))
+
+    # now we can make runningcatalog, we use first xtrsrc as trigger src
+    runningcatalog = gen_runningcatalog(xtrsrcs[0], dataset)
+
+    # create the associations. Can't do this directly since the
+    # association table has non nullable columns
+    for xtrsrc in xtrsrcs:
+        assocs.append(gen_assocxtrsource(runningcatalog, xtrsrc))
+
+    newsource = gen_newsource(runningcatalog, xtrsrcs[5], images[4])
+
+    # just return all db objects we created
+    return [dataset, band, skyregion, runningcatalog, newsource] + images + \
+           xtrsrcs + assocs


### PR DESCRIPTION
This replaces the augmented runningcatalog view. basically it does the same, but stores the result of the augmented runningcatalog view into a 'varmetric' table. Should by orders of magnitude faster during interactive use.

related banana issue: https://github.com/transientskp/banana/pull/101
