### PR TITLE
Runcat expire

### DIFF
--- a/documentation/devref/database/schema.rst
+++ b/documentation/devref/database/schema.rst
@@ -786,6 +786,13 @@ If no counterpart could be found for an extracted sources, it is appended to
     Boolean to indicate whether an entry is from the user-specified monitoring list.
     Default value is false.
 
+**forcedfits_count**
+    The number of forced fits performed since the last blind fit. Used to
+    'expire' the runningcatalog - else said to stop monitoring a source of
+    which the flux went below the detection threshold after a configurable
+    amount of timesteps. Controlled by the ``expiration`` configuration
+    variable.
+
 .. _schema-runningcatalog-flux:
 
 runningcatalog_flux

--- a/documentation/userref/config/job_params_cfg.rst
+++ b/documentation/userref/config/job_params_cfg.rst
@@ -109,6 +109,12 @@ See also :ref:`stage-extraction` and :ref:`stage-forcedfit`.
    are *stored* during the source-extraction process, they affect the
    source-association process.)
 
+`expiration`
+    The number of forced fits performed since the last blind fit. Used to
+    'expire' the runningcatalog - else said to stop monitoring a source of
+    which the flux went below the detection threshold after a configurable
+    amount of timesteps.
+
 
 .. _job_params_association:
 

--- a/tests/test_database/test_alchemy.py
+++ b/tests/test_database/test_alchemy.py
@@ -1,101 +1,16 @@
 import unittest
 import logging
-from datetime import datetime, timedelta
 
 import tkp.db
 import tkp.db.model
 import tkp.db.alchemy
 
+from tkp.testutil.alchemy import gen_band, gen_dataset, gen_skyregion,\
+    gen_lightcurve
+
 
 logging.basicConfig(level=logging.INFO)
 logging.getLogger('sqlalchemy.engine').setLevel(logging.WARNING)
-
-
-def gen_band(central=150**6, low=None, high=None):
-    if not low:
-        low = central * .9
-    if not high:
-        high = central * 1.1
-    return tkp.db.model.Frequencyband(freq_low=low, freq_central=central,
-                                      freq_high=high)
-
-
-def gen_dataset(description):
-    return tkp.db.model.Dataset(process_start_ts=datetime.now(),
-                                description=description)
-
-
-def gen_skyregion(dataset):
-    return tkp.db.model.Skyregion(dataset=dataset, centre_ra=1, centre_decl=1,
-                                  xtr_radius=1, x=1, y=1, z=1)
-
-
-def gen_image(band, dataset, skyregion, taustart_ts=None):
-    if not taustart_ts:
-        taustart_ts = datetime.now()
-    return tkp.db.model.Image(band=band, dataset=dataset, skyrgn=skyregion,
-                              freq_eff=2, rb_smin=1, taustart_ts=taustart_ts,
-                              rb_smaj=1, rb_pa=1, deltax=1, deltay=1, rms_qc=0)
-
-
-def gen_extractedsource(image):
-    return tkp.db.model.Extractedsource(zone=1, ra=1, decl=1, uncertainty_ew=1, x=1, y=1,
-                                        z=1, uncertainty_ns=1, ra_err=1, decl_err=1,
-                                        ra_fit_err=1, decl_fit_err=1, ew_sys_err=1,
-                                        ns_sys_err=1, error_radius=1, racosdecl=1,
-                                        det_sigma=1, f_int=0.01, image=image)
-
-
-def gen_runningcatalog(xtrsrc, dataset):
-    return tkp.db.model.Runningcatalog(xtrsrc=xtrsrc, dataset=dataset, datapoints=1,
-                                       zone=1, wm_ra=1., wm_decl=1, wm_uncertainty_ew=1,
-                                       wm_uncertainty_ns=1, avg_ra_err=1, avg_decl_err=1,
-                                       avg_wra=1, avg_wdecl=1, avg_weight_ra=1, avg_weight_decl=1,
-                                       x=1, y=1, z=1)
-
-
-def gen_assocxtrsource(runningcatalog, xtrsrc):
-    return tkp.db.model.Assocxtrsource(runcat=runningcatalog, xtrsrc=xtrsrc,
-                                       type=0, r=0, distance_arcsec=0, v_int=0,
-                                       eta_int=0, f_datapoints=0)
-
-
-def gen_newsource(runcat, xtrsrc, image):
-    return tkp.db.model.Newsource(runcat=runcat, trigger_xtrsrc=xtrsrc,
-                                  newsource_type=1, previous_limits_image=image)
-
-
-def gen_lightcurve(band, dataset, skyregion, datapoints=10):
-    """
-    returns: a list of created SQLAlchemy objects
-    """
-    start = datetime.fromtimestamp(0)
-    ten_sec = timedelta(seconds=10)
-    xtrsrcs = []
-    images = []
-    assocs = []
-    for i in range(datapoints):
-        taustart_ts = start + ten_sec * i
-        image = gen_image(band, dataset, skyregion, taustart_ts)
-
-        if i == 5:
-            image.int = 10
-        images.append(image)
-        xtrsrcs.append(gen_extractedsource(image))
-
-    # now we can make runningcatalog, we use first xtrsrc as trigger src
-    runningcatalog = gen_runningcatalog(xtrsrcs[0], dataset)
-
-    # create the associations. Can't do this directly since the
-    # association table has non nullable columns
-    for xtrsrc in xtrsrcs:
-        assocs.append(gen_assocxtrsource(runningcatalog, xtrsrc))
-
-    newsource = gen_newsource(runningcatalog, xtrsrcs[5], images[4])
-
-    # just return all db objects we created
-    return [dataset, band, skyregion, runningcatalog, newsource] + images + \
-           xtrsrcs + assocs
 
 
 class TestApi(unittest.TestCase):

--- a/tests/test_database/test_alchemy.py
+++ b/tests/test_database/test_alchemy.py
@@ -100,7 +100,7 @@ class TestApi(unittest.TestCase):
 
     def test_transient_newsource(self):
         """
-        Ra & Decl filtering
+        Check if we can filter on new source transients only
         """
         r = tkp.db.alchemy.transients(self.session, self.dataset1,
                                   new_src_only=True).all()

--- a/tests/test_database/test_expire.py
+++ b/tests/test_database/test_expire.py
@@ -1,0 +1,112 @@
+"""
+All tests related to the 'expiration' of extracted sources.
+
+Without expiration sources will *always* be extracted, also when the source
+was only above the detection threshold for one time. This introduces a lot of
+false positive light curves in the case of a noise image, and eventually the
+whole image will be monitored.
+
+"""
+import unittest
+from datetime import datetime, timedelta
+
+from tkp.db.database import Database
+from tkp.db.model import Runningcatalog
+from tkp.db.nulldetections import get_nulldetections, associate_nd
+
+from tkp.testutil.alchemy import gen_band, gen_dataset, gen_skyregion,\
+    gen_extractedsource, gen_runningcatalog, gen_assocskyrgn, \
+    gen_assocxtrsource, gen_image
+
+
+class TestExpire(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.database = Database()
+        cls.database.connect()
+
+    def setUp(self):
+        """
+        make a dataset with 10 images with 2 ligthcurves + one empty image
+        """
+        self.session = self.database.Session()
+        band = gen_band(central=150**6)
+        self.dataset = gen_dataset('expiring runningcatalog test')
+        skyregion = gen_skyregion(self.dataset)
+        datapoints = 10
+
+        start = datetime.fromtimestamp(0)
+        ten_sec = timedelta(seconds=10)
+        xtrsrcs1 = []
+        xtrsrcs2 = []
+        images = []
+        assocs = []
+        for i in range(datapoints):
+            taustart_ts = start + ten_sec * i
+            image = gen_image(band, self.dataset, skyregion, taustart_ts)
+
+            if i == 5:
+                image.int = 10
+            images.append(image)
+            xtrsrcs1.append(gen_extractedsource(image))
+            xtrsrcs2.append(gen_extractedsource(image))
+
+        # now we can make runningcatalog, we use first xtrsrc as trigger src
+        runningcatalog1 = gen_runningcatalog(xtrsrcs1[0], self.dataset)
+        runningcatalog2 = gen_runningcatalog(xtrsrcs2[0], self.dataset)
+        assocskyrgn1 = gen_assocskyrgn(runningcatalog1, skyregion)
+        assocskyrgn2 = gen_assocskyrgn(runningcatalog2, skyregion)
+
+        # create the associations. Can't do this directly since the
+        # association table has non nullable columns
+        for xtrsrc in xtrsrcs1:
+            assocs.append(gen_assocxtrsource(runningcatalog1, xtrsrc))
+        for xtrsrc in xtrsrcs2:
+            assocs.append(gen_assocxtrsource(runningcatalog2, xtrsrc))
+
+        self.empty_image = gen_image(band, self.dataset, skyregion, taustart_ts)
+
+        self.session.add_all([band, skyregion, runningcatalog1, runningcatalog2,
+                              assocskyrgn1, assocskyrgn2, self.empty_image] +
+                             images + xtrsrcs1 + xtrsrcs2 + assocs)
+        self.session.flush()
+        self.session.commit()
+
+    def test_nulldetections(self):
+        """
+        Check if get_nulldetections doesn't return expired runcats
+        """
+
+        # get all runningcatalog entries, should be two
+        runcats = self.session.query(Runningcatalog).\
+            filter(Runningcatalog.dataset == self.dataset).all()
+        self.assertEqual(len(runcats), 2)
+
+        # get_nulldetections before setting forcefits_count, should be 2
+        r = get_nulldetections(self.empty_image.id)
+        self.assertEqual(len(r), 2)
+
+        # set the forcedfits_count for one of the ligthcurves
+        runcats[0].forcedfits_count = 20
+        self.session.commit()
+
+        # fetch nulldetections, should be 1 now
+        r = get_nulldetections(self.empty_image.id)
+        self.assertEqual(len(r), 1)
+
+    def test_associate_nd(self):
+        """
+        Check if associate_nd increments the forcedfits_count column
+        """
+        associate_nd(self.empty_image.id)
+
+    def test_reset(self):
+        """
+        Check if 1-to-1 association resets expiration counter to 0
+        """
+        pass
+
+    def test_overall(self):
+        """
+        Black box test if running catalog entries expire
+        """

--- a/tkp/config/job_template/job_params.cfg
+++ b/tkp/config/job_template/job_params.cfg
@@ -28,6 +28,7 @@ box_in_beampix = 10
 # See Dario Carbone's presentation at TKP Meeting 2012/12/04
 ew_sys_err = 10
 ns_sys_err = 10
+expiration = 10  ; number of forced fits performed after a blind fit
 
 [association]
 deruiter_radius = 5.68

--- a/tkp/db/associations.py
+++ b/tkp/db/associations.py
@@ -1479,6 +1479,7 @@ def _update_1_to_1_runcat():
                      WHERE temprunningcatalog.runcat = runningcatalog.id
                           AND temprunningcatalog.inactive = FALSE
                    )
+              ,forcedfits_count = 0
          WHERE EXISTS (SELECT runcat
                          FROM temprunningcatalog
                         WHERE temprunningcatalog.runcat = runningcatalog.id

--- a/tkp/db/model.py
+++ b/tkp/db/model.py
@@ -1,3 +1,11 @@
+"""
+The SQLAlchemy model definition.
+
+revision history:
+
+ 37 - add forcedfits_count column to runningcatalog
+ 36 - switch to SQLAlchemy schema initialisation
+"""
 
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Index,\
     Integer, SmallInteger, String, text, Sequence
@@ -7,7 +15,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION as Double
 
 
-SCHEMA_VERSION = 36
+SCHEMA_VERSION = 37
 
 Base = declarative_base()
 metadata = Base.metadata
@@ -289,6 +297,7 @@ class Runningcatalog(Base):
     z = Column(Double, nullable=False, index=True)
     inactive = Column(Boolean, nullable=False, server_default=text("false"))
     mon_src = Column(Boolean, nullable=False, server_default=text("false"))
+    forcedfits_count = Column(Integer, server_default=text("0"))
 
     extractedsources = relationship('Extractedsource',
                                     secondary='assocxtrsource',

--- a/tkp/db/model.py
+++ b/tkp/db/model.py
@@ -97,6 +97,12 @@ class Dataset(Base):
     nodes = Column(SmallInteger, nullable=False, server_default=text("1"))
 
 
+# extractedsource types
+BLIND_FIT = 0
+FORCED_FIT = 1
+MONITORED_FIT = 2
+
+
 class Extractedsource(Base):
     __tablename__ = 'extractedsource'
 

--- a/tkp/db/nulldetections.py
+++ b/tkp/db/nulldetections.py
@@ -96,6 +96,7 @@ def associate_nd(image_id):
     _del_tempruncat()
     _insert_tempruncat(image_id)
     _insert_1_to_1_assoc()
+    _increment_forcedfits_count()
 
     n_updated = _update_1_to_1_runcat_flux()
     if n_updated:
@@ -105,6 +106,24 @@ def associate_nd(image_id):
         logger.debug("Inserted new-band flux measurement for %s null_detections"
                     % n_inserted)
     _del_tempruncat()
+
+
+def _increment_forcedfits_count():
+    """
+    Increment the forcedfits count for every runningcatalog entry in the
+    temprunningcatalog table.
+    """
+    query = """\
+update runningcatalog
+set forcedfits_count = forcedfits_count + 1
+where id in (
+    select t.runcat
+    from temprunningcatalog t, runningcatalog r
+    where t.runcat = r.id
+);
+"""
+    execute(query)
+
 
 def _insert_tempruncat(image_id):
     """

--- a/tkp/db/nulldetections.py
+++ b/tkp/db/nulldetections.py
@@ -12,6 +12,7 @@ from tkp.db.associations import (
 
 logger = logging.getLogger(__name__)
 
+
 def get_nulldetections(image_id, expiration=10):
     """
     Returns the runningcatalog sources which:
@@ -114,13 +115,19 @@ def _increment_forcedfits_count():
     temprunningcatalog table.
     """
     query = """\
-update runningcatalog
-set forcedfits_count = forcedfits_count + 1
-where id in (
-    select t.runcat
-    from temprunningcatalog t, runningcatalog r
-    where t.runcat = r.id
-);
+UPDATE
+    runningcatalog
+SET
+    forcedfits_count = forcedfits_count + 1
+WHERE id IN (
+    SELECT
+        t.runcat
+    FROM
+        temprunningcatalog t,
+        runningcatalog r
+    WHERE
+        t.runcat = r.id
+)
 """
     execute(query)
 

--- a/tkp/db/nulldetections.py
+++ b/tkp/db/nulldetections.py
@@ -12,7 +12,7 @@ from tkp.db.associations import (
 
 logger = logging.getLogger(__name__)
 
-def get_nulldetections(image_id):
+def get_nulldetections(image_id, expiration=10):
     """
     Returns the runningcatalog sources which:
 
@@ -29,6 +29,10 @@ def get_nulldetections(image_id):
     Sources which have not been seen earlier, and which appear in
     different bands at the current timestep, are *not* null detections,
     but are considered as "new" sources.
+
+    args:
+        image_id (int): database ID of image
+        expiration (int): number of forced fits performed after a blind fit):
 
     Returns: list of tuples [(runcatid, ra, decl)]
     """
@@ -56,6 +60,7 @@ SELECT t0.id
          WHERE i0.id = %(image_id)s
            AND a0.skyrgn = i0.skyrgn
            AND r0.id = a0.runcat
+           AND r0.forcedfits_count < %(expiration)s
            AND x0.id = r0.xtrsrc
            AND i1.id = x0.image
            AND i0.taustart_ts > i1.taustart_ts
@@ -69,7 +74,7 @@ SELECT t0.id
        ON t0.id = t1.runcat
  WHERE t1.runcat IS NULL
 """
-    qry_params = {'image_id': image_id}
+    qry_params = {'image_id': image_id, 'expiration': expiration}
     cursor = execute(query, qry_params)
     res = cursor.fetchall()
     return res

--- a/tkp/main.py
+++ b/tkp/main.py
@@ -156,7 +156,9 @@ def run(job_name, supplied_mon_coords=[]):
                                               deRuiter_r=deruiter_radius,
                                               new_source_sigma_margin=new_src_sigma)
 
-            all_fit_posns, all_fit_ids = steps_ff.get_forced_fit_requests(image)
+            expiration = job_config.source_extraction.expiration
+            all_fit_posns, all_fit_ids = steps_ff.get_forced_fit_requests(image,
+                                                                          expiration)
             if all_fit_posns:
                 successful_fits, successful_ids = steps_ff.perform_forced_fits(
                     all_fit_posns, all_fit_ids, image.url, se_parset)

--- a/tkp/steps/forced_fitting.py
+++ b/tkp/steps/forced_fitting.py
@@ -9,8 +9,8 @@ from tkp.db import nulldetections as dbnd
 logger = logging.getLogger(__name__)
 
 
-def get_forced_fit_requests(image):
-    nd_requested_fits = dbnd.get_nulldetections(image.id)
+def get_forced_fit_requests(image, expiration):
+    nd_requested_fits = dbnd.get_nulldetections(image.id, expiration)
     logger.info("Found %s null detections" % len(nd_requested_fits))
     mon_entries = dbmon.get_monitor_entries(image.dataset.id)
 

--- a/tkp/testutil/alchemy.py
+++ b/tkp/testutil/alchemy.py
@@ -88,7 +88,8 @@ def gen_lightcurve(band, dataset, skyregion, datapoints=10):
     for xtrsrc in xtrsrcs:
         assocs.append(gen_assocxtrsource(runningcatalog, xtrsrc))
 
+    newsource = gen_newsource(runningcatalog, xtrsrcs[5], images[4])
 
     # just return all db objects we created
-    return [dataset, band, skyregion, runningcatalog, assocskyrgn] + \
+    return [dataset, band, skyregion, runningcatalog, assocskyrgn, newsource] + \
            images + xtrsrcs + assocs

--- a/tkp/testutil/alchemy.py
+++ b/tkp/testutil/alchemy.py
@@ -45,6 +45,11 @@ def gen_runningcatalog(xtrsrc, dataset):
                                        x=1, y=1, z=1)
 
 
+def gen_assocskyrgn(runcat, skyrgn):
+    return tkp.db.model.Assocskyrgn(runcat=runcat, skyrgn=skyrgn,
+                                    distance_deg=10)
+
+
 def gen_assocxtrsource(runningcatalog, xtrsrc):
     return tkp.db.model.Assocxtrsource(runcat=runningcatalog, xtrsrc=xtrsrc,
                                        type=0, r=0, distance_arcsec=0, v_int=0,
@@ -76,14 +81,14 @@ def gen_lightcurve(band, dataset, skyregion, datapoints=10):
 
     # now we can make runningcatalog, we use first xtrsrc as trigger src
     runningcatalog = gen_runningcatalog(xtrsrcs[0], dataset)
+    assocskyrgn = gen_assocskyrgn(runningcatalog, skyregion)
 
     # create the associations. Can't do this directly since the
     # association table has non nullable columns
     for xtrsrc in xtrsrcs:
         assocs.append(gen_assocxtrsource(runningcatalog, xtrsrc))
 
-    newsource = gen_newsource(runningcatalog, xtrsrcs[5], images[4])
 
     # just return all db objects we created
-    return [dataset, band, skyregion, runningcatalog, newsource] + images + \
-           xtrsrcs + assocs
+    return [dataset, band, skyregion, runningcatalog, assocskyrgn] + \
+           images + xtrsrcs + assocs

--- a/tkp/testutil/sqlalchemy.py
+++ b/tkp/testutil/sqlalchemy.py
@@ -1,0 +1,89 @@
+from datetime import datetime, timedelta
+import tkp.db
+
+
+def gen_band(central=150**6, low=None, high=None):
+    if not low:
+        low = central * .9
+    if not high:
+        high = central * 1.1
+    return tkp.db.model.Frequencyband(freq_low=low, freq_central=central,
+                                      freq_high=high)
+
+
+def gen_dataset(description):
+    return tkp.db.model.Dataset(process_start_ts=datetime.now(),
+                                description=description)
+
+
+def gen_skyregion(dataset):
+    return tkp.db.model.Skyregion(dataset=dataset, centre_ra=1, centre_decl=1,
+                                  xtr_radius=1, x=1, y=1, z=1)
+
+
+def gen_image(band, dataset, skyregion, taustart_ts=None):
+    if not taustart_ts:
+        taustart_ts = datetime.now()
+    return tkp.db.model.Image(band=band, dataset=dataset, skyrgn=skyregion,
+                              freq_eff=2, rb_smin=1, taustart_ts=taustart_ts,
+                              rb_smaj=1, rb_pa=1, deltax=1, deltay=1, rms_qc=0)
+
+
+def gen_extractedsource(image):
+    return tkp.db.model.Extractedsource(zone=1, ra=1, decl=1, uncertainty_ew=1, x=1, y=1,
+                                        z=1, uncertainty_ns=1, ra_err=1, decl_err=1,
+                                        ra_fit_err=1, decl_fit_err=1, ew_sys_err=1,
+                                        ns_sys_err=1, error_radius=1, racosdecl=1,
+                                        det_sigma=1, f_int=0.01, image=image)
+
+
+def gen_runningcatalog(xtrsrc, dataset):
+    return tkp.db.model.Runningcatalog(xtrsrc=xtrsrc, dataset=dataset, datapoints=1,
+                                       zone=1, wm_ra=1., wm_decl=1, wm_uncertainty_ew=1,
+                                       wm_uncertainty_ns=1, avg_ra_err=1, avg_decl_err=1,
+                                       avg_wra=1, avg_wdecl=1, avg_weight_ra=1, avg_weight_decl=1,
+                                       x=1, y=1, z=1)
+
+
+def gen_assocxtrsource(runningcatalog, xtrsrc):
+    return tkp.db.model.Assocxtrsource(runcat=runningcatalog, xtrsrc=xtrsrc,
+                                       type=0, r=0, distance_arcsec=0, v_int=0,
+                                       eta_int=0, f_datapoints=0)
+
+
+def gen_newsource(runcat, xtrsrc, image):
+    return tkp.db.model.Newsource(runcat=runcat, trigger_xtrsrc=xtrsrc,
+                                  newsource_type=1, previous_limits_image=image)
+
+
+def gen_lightcurve(band, dataset, skyregion, datapoints=10):
+    """
+    returns: a list of created SQLAlchemy objects
+    """
+    start = datetime.fromtimestamp(0)
+    ten_sec = timedelta(seconds=10)
+    xtrsrcs = []
+    images = []
+    assocs = []
+    for i in range(datapoints):
+        taustart_ts = start + ten_sec * i
+        image = gen_image(band, dataset, skyregion, taustart_ts)
+
+        if i == 5:
+            image.int = 10
+        images.append(image)
+        xtrsrcs.append(gen_extractedsource(image))
+
+    # now we can make runningcatalog, we use first xtrsrc as trigger src
+    runningcatalog = gen_runningcatalog(xtrsrcs[0], dataset)
+
+    # create the associations. Can't do this directly since the
+    # association table has non nullable columns
+    for xtrsrc in xtrsrcs:
+        assocs.append(gen_assocxtrsource(runningcatalog, xtrsrc))
+
+    newsource = gen_newsource(runningcatalog, xtrsrcs[5], images[4])
+
+    # just return all db objects we created
+    return [dataset, band, skyregion, runningcatalog, newsource] + images + \
+           xtrsrcs + assocs


### PR DESCRIPTION
 - [x] add a `forcedfits_count` column to `runningcatalog` table with default value 0: https://github.com/transientskp/tkp/blob/master/tkp/db/sql/statements/tables/runningcatalog.sql#L21

 - [x] add a argument `forcedfits_max` to `get_nulldetections`, add a check to the query that filter the result on if the `forcedfits_count` column value of runningcatalog table is below `forcedfits_max` .  https://github.com/transientskp/tkp/blob/master/tkp/db/nulldetections.py#L15

 - [x] in the `associate_nd` function in `nulldetections.py` we need to add a new query that will increment the forcedfits_count column of a runningcatalog entry for every forced fits. https://github.com/transientskp/tkp/blob/master/tkp/db/nulldetections.py#L78

 - [x] in `_update_1_to_1_runcat` in `associations.py` we should add a statement that always resets `forcedfits_count` to 0. https://github.com/transientskp/tkp/blob/master/tkp/db/associations.py#L1480

original issue https://github.com/transientskp/tkp/issues/456

related banana issue https://github.com/transientskp/tkp/pull/472
