### PR TITLE
Add new rejectreason

### DIFF
--- a/tkp/db/sql/statements/init/rejectreasons.sql
+++ b/tkp/db/sql/statements/init/rejectreasons.sql
@@ -2,3 +2,4 @@ INSERT INTO rejectreason VALUES (0, 'RMS invalid');
 INSERT INTO rejectreason VALUES (1, 'beam invalid');
 INSERT INTO rejectreason VALUES (2, 'bright source near');
 INSERT INTO rejectreason VALUES (3, 'tau_time invalid');
+INSERT INTO rejectreason VALUES (4, 'Contains NaN value');


### PR DESCRIPTION
Python contains a NaN reject reason that's not yet reflected in the database. This patch makes sure it is.