### PR TITLE
Store varmetric values in a table

### DIFF
--- a/documentation/devref/database/schema.rst
+++ b/documentation/devref/database/schema.rst
@@ -911,6 +911,48 @@ tables are listed below.
 
 
 
+varmetric
+=========
+
+This table contains precalculated lightcurve properties, which can be used
+for filtering and isolating potential transients.
+
+**runcat**
+    Reference to the ``runningcatalog`` ``id``.
+
+**v_int**
+    The flux `coefficient of variation <coeff-of-var_>`_ , :math:`V_{\nu}`,
+    based on the integrated flux values up to this datapoint.
+
+**eta_int**
+    The 'reduced chi-squared' variability index, :math:`\eta_{\nu}`, based on
+    the integrated flux values up to this datapoint.
+
+**band**
+    Reference to the ``band`` ``id``.
+
+**newsource**
+    Reference to the ``newsource`` ``id``.
+
+**sigma_rms_max**
+    Integrated flux from the from the extractedsource that triggered an new source
+    entry divided by the *maximum* value of the estimated-RMS-map within the
+    source-extraction region of the previous limits image.
+
+
+**sigma_rms_min**
+    Integrated flux from the from the extractedsource that triggered an new source
+    entry divided by the *minimum* value of the estimated-RMS-map within the
+    source-extraction region of the previous limits image.
+
+**lightcurve_max**
+    The maximum flux value of the lightcurve
+
+**lightcurve_avg**
+    The average flux value of the lightcurve
+
+**lightcurve_median**
+    The median flux value of the lightcurve
 
 
 

--- a/tests/test_database/test_alchemy.py
+++ b/tests/test_database/test_alchemy.py
@@ -1,16 +1,18 @@
 import unittest
 import logging
+from datetime import datetime, timedelta
 
 import tkp.db
 import tkp.db.model
 import tkp.db.alchemy
 
-from tkp.testutil.alchemy import gen_band, gen_dataset, gen_skyregion,\
+from tkp.testutil.alchemy import gen_band, gen_dataset, gen_skyregion, \
     gen_lightcurve
-
 
 logging.basicConfig(level=logging.INFO)
 logging.getLogger('sqlalchemy.engine').setLevel(logging.WARNING)
+
+
 
 
 class TestApi(unittest.TestCase):
@@ -65,43 +67,56 @@ class TestApi(unittest.TestCase):
         shouldbe = [1.0, 1.0, 1.0, 1.0, 1, 0.0, 0.0, None, None, 0.01, 0.01]
         self.assertEqual(r, shouldbe)
 
-    def test_transient(self):
-        r = tkp.db.alchemy.transients(self.session, self.dataset1).all()
+    def test_calculate_varmetric(self):
+        r = tkp.db.alchemy.calculate_varmetric(self.session, self.dataset1).all()
         self.assertEqual(len(r), 2)
 
-    def test_transient_region(self):
+    def test_calculate_varmetric_region(self):
         """
         Ra & Decl filtering
         """
-        r = tkp.db.alchemy.transients(self.session, self.dataset1, ra_range=(0, 2),
+        r = tkp.db.alchemy.calculate_varmetric(self.session, self.dataset1,
+                                               ra_range=(0, 2),
                                   decl_range=(0, 2)).all()
         self.assertEqual(len(r), 2)
 
-        r = tkp.db.alchemy.transients(self.session, self.dataset1, ra_range=(20, 22),
+        r = tkp.db.alchemy.calculate_varmetric(self.session, self.dataset1,
+                                               ra_range=(20, 22),
                                   decl_range=(20, 22)).all()
         self.assertEqual(len(r), 0)
 
-    def test_transient_cutoff(self):
+    def test_calculate_varmetric_cutoff(self):
         """
         V_int & eta_int filtering
         """
-        r = tkp.db.alchemy.transients(self.session, self.dataset1, v_int_min=0,
+        r = tkp.db.alchemy.calculate_varmetric(self.session, self.dataset1,
+                                               v_int_min=0,
                                   eta_int_min=0).all()
         self.assertEqual(len(r), 2)
 
-        q = tkp.db.alchemy.transients(self.session, self.dataset1, v_int_min=1000,
+        q = tkp.db.alchemy.calculate_varmetric(self.session, self.dataset1,
+                                               v_int_min=1000,
                                   eta_int_min=0)
         r = q.all()
         self.assertEqual(len(r), 0)
 
-        r = tkp.db.alchemy.transients(self.session, self.dataset1, v_int_min=0,
+        r = tkp.db.alchemy.calculate_varmetric(self.session, self.dataset1,
+                                               v_int_min=0,
                                   eta_int_min=1000).all()
         self.assertEqual(len(r), 0)
 
-    def test_transient_newsource(self):
+    def test_calculate_varmetric_newsource(self):
         """
-        Check if we can filter on new source transients only
+        Ra & Decl filtering
         """
-        r = tkp.db.alchemy.transients(self.session, self.dataset1,
+        r = tkp.db.alchemy.calculate_varmetric(self.session, self.dataset1,
                                   new_src_only=True).all()
+        self.assertEqual(len(r), 2)
+
+    def test_store_varmetric(self):
+        q = tkp.db.alchemy.store_varmetric(self.session, self.dataset1)
+        self.session.execute(q)
+        r = self.session.query(tkp.db.model.Varmetric).\
+            join(tkp.db.model.Varmetric.runcat).\
+            filter_by(dataset=self.dataset1).all()
         self.assertEqual(len(r), 2)

--- a/tests/test_steps/test_varmetric.py
+++ b/tests/test_steps/test_varmetric.py
@@ -1,0 +1,38 @@
+import unittest
+import logging
+
+import tkp.db.model
+
+from tkp.testutil.alchemy import gen_band, gen_dataset, gen_skyregion,\
+    gen_lightcurve
+
+import tkp.db
+import tkp.db.alchemy
+
+from tkp.steps.varmetric import execute_store_varmetric
+
+
+logging.basicConfig(level=logging.INFO)
+logging.getLogger('sqlalchemy.engine').setLevel(logging.WARNING)
+
+
+class TestApi(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.db = tkp.db.Database()
+        cls.db.connect()
+
+    def setUp(self):
+        self.session = self.db.Session()
+
+        band = gen_band(central=150**6)
+        self.dataset = gen_dataset('test varmetric step')
+        skyregion = gen_skyregion(self.dataset)
+        lightcurve = gen_lightcurve(band, self.dataset, skyregion)
+        self.session.add_all(lightcurve)
+        self.session.flush()
+        self.session.commit()
+
+    def test_execute_store_varmetric(self):
+        session = self.db.Session()
+        execute_store_varmetric(session=session, dataset_id=self.dataset.id)

--- a/tkp/db/model.py
+++ b/tkp/db/model.py
@@ -309,6 +309,32 @@ class Runningcatalog(Base):
                                     secondary='assocxtrsource',
                                     backref='runningcatalogs')
 
+    varmetric = relationship("Varmetric", uselist=False, backref="runcat")
+
+
+class Varmetric(Base):
+    __tablename__ = 'varmetric'
+
+    id = Column(Integer, primary_key=True)
+
+    runcat_id = Column('runcat', ForeignKey('runningcatalog.id'),
+                       nullable=False, index=True)
+
+    v_int = Column(Double, index=True)
+    eta_int = Column(Double)
+
+    band_id = Column('band', ForeignKey('frequencyband.id'), nullable=False,
+                     index=True)
+    band = relationship('Frequencyband')
+
+    newsource = Column(Integer)
+    sigma_rms_max = Column(Double, index=True)
+    sigma_rms_min = Column(Double, index=True)
+    lightcurve_max = Column(Double, index=True)
+    lightcurve_avg = Column(Double, index=True)
+    lightcurve_median = Column(Double, index=True)
+
+
 class RunningcatalogFlux(Base):
     __tablename__ = 'runningcatalog_flux'
     __table_args__ = (

--- a/tkp/main.py
+++ b/tkp/main.py
@@ -19,6 +19,7 @@ from tkp.steps.misc import (load_job_config, dump_configs_to_logdir,
 from tkp.db.configstore import store_config, fetch_config
 from tkp.steps.persistence import create_dataset, store_images
 import tkp.steps.forced_fitting as steps_ff
+from tkp.steps.varmetric import execute_store_varmetric
 
 
 logger = logging.getLogger(__name__)
@@ -168,3 +169,6 @@ def run(job_name, supplied_mon_coords=[]):
 
 
         dbgen.update_dataset_process_end_ts(dataset_id)
+
+    logger.info("calculating variability metrics")
+    execute_store_varmetric(dataset_id)

--- a/tkp/steps/varmetric.py
+++ b/tkp/steps/varmetric.py
@@ -1,0 +1,22 @@
+from tkp.db.alchemy import store_varmetric
+from tkp.db.model import Dataset
+from tkp.db import Database
+
+
+def execute_store_varmetric(dataset_id, session=None):
+    """
+    Executes the storing varmetric function. Will create a database session
+    if none is supplied
+
+    args:
+        dataset_id: the ID of the dataset for which you want to store the varmetrics
+        session: An optional SQLAlchemy session
+    """
+    if not session:
+        database = Database()
+        session = database.Session()
+
+    dataset = Dataset(id=dataset_id)
+    query = store_varmetric(session, dataset=dataset)
+    session.execute(query)
+    session.commit()

--- a/tkp/testutil/alchemy.py
+++ b/tkp/testutil/alchemy.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta
 import tkp.db
 
-
 def gen_band(central=150**6, low=None, high=None):
     if not low:
         low = central * .9
@@ -43,8 +42,6 @@ def gen_runningcatalog(xtrsrc, dataset):
                                        wm_uncertainty_ns=1, avg_ra_err=1, avg_decl_err=1,
                                        avg_wra=1, avg_wdecl=1, avg_weight_ra=1, avg_weight_decl=1,
                                        x=1, y=1, z=1)
-
-
 def gen_assocskyrgn(runcat, skyrgn):
     return tkp.db.model.Assocskyrgn(runcat=runcat, skyrgn=skyrgn,
                                     distance_deg=10)


### PR DESCRIPTION
Rebased version of https://github.com/transientskp/tkp/pull/469
(Actually the rebase was non-trivial, which is why I didn't force-push over the old branch. Think I got it, though.)

Hey @gijzelaerr ,
took a look at this, looks good (I think! It's taken me all day just to get back up to speed, so I've not dived deep into the queries). 

Two concrete suggestions:
- If we're switching to sqlalchemy in general, then probably we should rename tkp.db.sql.alchemy to something more specific now - tkp.db.sql.varmetric? Similarly for  'tests/test_database/test_alchemy'
- Would be good to have an entry in the docs for the varmetric table, explaining what the column values represent, alternatively put that in the relevant docstring and figure out how to pull it into the docs. (Actually, now the db-models are in Python we could probably use docstrings throughout, but that's a bigger job.)

And some comments:
- How much work will it be to fix-up Banana to match - I guess the varmetric table just behaves as the old augmented runcat view, so not much?

- In the long run, I'm not sure it's worth having a wrapper function (tkp.tkp.steps.varmetric.execute_store_varmetric). Probably clearer to just have session management out in the open in tkp.main? Though I guess it's a bit awkward right now while we're still mixing old code. Leave it for now I guess, but we should have a think about whether we're going to have session management visible at the top-level, or replace the home-grown `Database` singleton with a sqlalchemy sessionmaker.

- From a quick glance, it looks like there's a lot of overlapping functionality in tkp.testutil.alchemy and the older tkp.testutil.db_subs. I don't blame you for avoiding that code - it was written in a hurry and could probably use some love - but it does quite a lot of work behind the scenes in setting up mock data. Probably we want to merge and improve this functionality, though it's a job in itself to do so. 

- I'm a bit worried that we don't actually test the varmetrics very carefully, though that's been the case since we first implemented the 'augmented running catalog view' while crunching for release 2.0. Ideally we should test them against a known dataset, but actually testing properly needs quite complex mock-data -> goes back to previous point about cleaning up mock-data functions.

</brain-dump> Probably some of this should go in an issue... tomorrow.