### PR TITLE
Rework logging functionality for main pipeline.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,21 +3,21 @@ from setuptools import setup, find_packages
 from tkp import __version__ as tkp_version
 
 install_requires = """
-    numpy>=1.3.0
-    scipy>=0.7.0
     astropy
+    colorlog
+    numpy>=1.3.0
+    psycopg2
+    python-casacore
     python-dateutil>=1.4.1
     pytz
     pywcs>=1.12
-    python-casacore
-    psycopg2
+    scipy>=0.7.0
     sqlalchemy>=1.0.0
     """.split()
 
 extras_require = {
     'pixelstore': ['pymongo>=3.0'],
     'monetdb': ['python-monetdb>=11.11.11', 'sqlalchemy_monetdb>=0.9.1'],
-    'distribute' : [ 'celery>=3.1.11']
 }
 
 tkp_scripts = [

--- a/tkp/config/project_template/pipeline.cfg
+++ b/tkp/config/project_template/pipeline.cfg
@@ -6,6 +6,7 @@ job_directory = %(runtime_directory)s/%(job_name)s
 #log_dir contains output log, plus a copy of the config files used.
 log_dir = %(job_directory)s/logs/%(start_time)s
 debug = False
+colorlog = True
 
 [database]
 engine = ;(monetdb or postgresql)

--- a/tkp/db/general.py
+++ b/tkp/db/general.py
@@ -245,7 +245,7 @@ def insert_extracted_sources(image_id, results, extract_type,
           source-distance calculations
     """
     if not len(results):
-        logger.info("No extract_type=%s sources added to extractedsource for"
+        logger.debug("No extract_type=%s sources added to extractedsource for"
                     " image %s" % (extract_type, image_id))
         return
 
@@ -255,7 +255,8 @@ def insert_extracted_sources(image_id, results, extract_type,
         # Drop any fits with infinite flux errors
         if math.isinf(r[5]) or math.isinf(r[7]):
             logger.warn("Dropped source fit with infinite flux errors "
-                        "at position %s %s" % (r[0], r[1]))
+                        "at position {} {} in image {}".format(
+                r[0], r[1], image_id))
             continue
         # Use 360 degree rather than infinite uncertainty for
         # unconstrained positions.
@@ -348,13 +349,13 @@ VALUES {placeholder}
         #    logger.info("No forced-fit sources added to extractedsource for "
         #                "image %s" % (image_id,))
         if extract_type == 'blind':
-            logger.info("Inserted %d sources in extractedsource for image %s" %
+            logger.debug("Inserted %d sources in extractedsource for image %s" %
                         (insert_num, image_id))
         elif extract_type == 'ff_nd':
-            logger.info("Inserted %d forced-fit null detections in extractedsource"
+            logger.debug("Inserted %d forced-fit null detections in extractedsource"
                         " for image %s" % (insert_num, image_id))
         elif extract_type == 'ff_ms':
-            logger.info("Inserted %d forced-fit for monitoring in extractedsource"
+            logger.debug("Inserted %d forced-fit for monitoring in extractedsource"
                         " for image %s" % (insert_num, image_id))
 
 

--- a/tkp/distribute/serial/tasks.py
+++ b/tkp/distribute/serial/tasks.py
@@ -7,16 +7,16 @@ logger = logging.getLogger(__name__)
 
 
 def persistence_node_step(images, image_cache_config, sigma, f):
-    logger.info("running persistence task")
+    logger.debug("running persistence task")
     return tkp.steps.persistence.node_steps(images, image_cache_config,
                                             sigma, f)
 
 
 def quality_reject_check(url, job_config):
-    logger.info("running quality task")
+    logger.debug("running quality task")
     return tkp.steps.quality.reject_check(url, job_config)
 
 
 def extract_sources(url, extraction_params):
-    logger.info("running extracted sources task")
+    logger.debug("running extracted sources task")
     return tkp.steps.source_extraction.extract_sources(url, extraction_params)

--- a/tkp/management.py
+++ b/tkp/management.py
@@ -27,7 +27,7 @@ import tkp
 from tkp.db.sql.populate import populate
 from tkp.main import run
 
-logging.basicConfig(level=logging.INFO)
+# logging.basicConfig(level=logging.INFO)
 
 
 class CommandError(Exception):

--- a/tkp/steps/persistence.py
+++ b/tkp/steps/persistence.py
@@ -49,9 +49,7 @@ def image_to_mongodb(filename, hostname, port, db):
             logger.info("Saved local copy of %s on %s"\
                         % (os.path.basename(filename), hostname))
     except Exception, e:
-        msg = "Failed to save image to MongoDB: %s" % (str(e),)
-        logger.error(msg)
-        warnings.warn(msg)
+        logger.exception("Failed to save image to MongoDB: {}".format(filename))
         return False
 
     finally:

--- a/tkp/steps/source_extraction.py
+++ b/tkp/steps/source_extraction.py
@@ -26,10 +26,9 @@ def extract_sources(image_path, extraction_params):
         list of ExtractionResults named tuples containing source measurements,
         min RMS value and max RMS value
     """
-    logger.info("Extracting image: %s" % image_path)
-    accessor = tkp.accessors.open(image_path)
     logger.debug("Detecting sources in image %s at detection threshold %s",
                  image_path, extraction_params['detection_threshold'])
+    accessor = tkp.accessors.open(image_path)
     data_image = sourcefinder_image_from_accessor(accessor,
                     margin=extraction_params['margin'],
                     radius=extraction_params['extraction_radius_pix'],


### PR DESCRIPTION
**Note change to pipeline.cfg**
This adds a line to the ``logging`` section of *pipeline.cfg*:

    [logging]
    colorlog = True

---------------

Partly in response to #501, but I've been meaning to tidy this up
for a while.

Note that we still lose all logs from pool-processes when
'multiprocessing' mode is employed. Something to work on.