### PR TITLE
add alembic working files

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,67 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts
+script_location = alembic
+
+# template used to generate migration files
+# file_template = %%(rev)s_%%(slug)s
+
+# max length of characters to apply to the
+# "slug" field
+#truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; this defaults
+# to alembic/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path
+# version_locations = %(here)s/bar %(here)s/bat alembic/versions
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+sqlalchemy.url = postgresql://user:pass@localhost/dbname
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/alembic/README
+++ b/alembic/README
@@ -1,0 +1,31 @@
+To find out how to work with migrations read the docs
+
+https://alembic.readthedocs.io/en/latest/autogenerate.html
+
+you can work on a specific TKP database by settings these
+environment variables:
+
+ - TKP_DBENGINE
+ - TKP_DBNAME
+ - TKP_DBUSER
+ - TKP_DBPASSWORD
+ - TKP_DBHOST
+ - TKP_DBPORT
+
+This is similar to how we configure the test suite:
+
+http://tkp.readthedocs.io/en/latest/devref/procedures/testing.html#database
+
+annoying thing is that for now you also need to set the database config
+in the alembic.ini file (sqlalchemy.url)
+
+basically to create a migration you should modify the model and then run:
+
+$ alembic revision --autogenerate -m "description"
+
+and then check the generated migration.
+
+An end user can then upgrade to the latest version using:
+
+$ alembic upgrade head
+

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,84 @@
+from __future__ import with_statement
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+from logging.config import fileConfig
+import os
+import getpass
+from tkp.db.model import Base
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+target_metadata = Base.metadata
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def get_url():
+    user = getpass.getuser()
+    engine = os.environ.get('TKP_DBENGINE', 'postgresql')
+    name = os.environ.get('TKP_DBNAME', user)
+    user = os.environ.get('TKP_DBUSER', user)
+    password = os.environ.get('TKP_DBPASSWORD', user)
+    host = os.environ.get('TKP_DBHOST', 'localhost')
+    port = os.environ.get('TKP_DBPORT', '5432')
+    return '%s://%s:%s@%s:%s/%' % ( engine, user, password, host, port, name )
+
+
+def run_migrations_offline():
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = get_url()
+    context.configure(
+        url=url, target_metadata=target_metadata, literal_binds=True)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix='sqlalchemy.',
+        poolclass=pool.NullPool)
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/alembic/versions/e3b50f666fbb_the_first_alembic_revision.py
+++ b/alembic/versions/e3b50f666fbb_the_first_alembic_revision.py
@@ -1,0 +1,24 @@
+"""the first alembic revision
+
+Revision ID: e3b50f666fbb
+Revises: 
+Create Date: 2016-05-30 11:32:22.585690
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'e3b50f666fbb'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ install_requires = """
     pywcs>=1.12
     scipy>=0.7.0
     sqlalchemy>=1.0.0
+    alembic
     """.split()
 
 extras_require = {


### PR DESCRIPTION
This is one of first steps for creating migrations. It is actually easy to use, only problem is that it doesn't fit nicely into the trap-manage.py command for end user usage yet.

When properly configured you can use alembic to generate up and downgrade scripts and run these to update existing databases. I suggest we start using this now, since we can then already create migrations scripts.