### PR TITLE
Fixed beamwidths_limit

### DIFF
--- a/tkp/main.py
+++ b/tkp/main.py
@@ -254,8 +254,10 @@ def assocate_and_get_force_fits(db_image, job_config):
                                                                     db_image.url))
 
     r = job_config.association.deruiter_radius
+    b = job_config.association.beamwidths_limit
     s = job_config.transient_search.new_source_sigma_margin
     dbass.associate_extracted_sources(db_image.id, deRuiter_r=r,
+                                      beamwidths_limit=b,
                                       new_source_sigma_margin=s)
 
     expiration = job_config.source_extraction.expiration


### PR DESCRIPTION
The parameter beamwidths_limit is now read in from job_params.cfg and used.

Tested with my mentioned offset image in issue #562 and now associations are made as expected.

Fixes issue #562.