### PR TITLE
Add capability to skip all tests requiring the DB.

### DIFF
--- a/tests/test_database/test_alchemy.py
+++ b/tests/test_database/test_alchemy.py
@@ -9,6 +9,7 @@ import tkp.db.model
 
 from tkp.testutil.alchemy import gen_band, gen_dataset, gen_skyregion, \
     gen_lightcurve
+from tkp.testutil.decorators import database_disabled
 
 logging.basicConfig(level=logging.INFO)
 logging.getLogger('sqlalchemy.engine').setLevel(logging.WARNING)
@@ -17,6 +18,11 @@ logging.getLogger('sqlalchemy.engine').setLevel(logging.WARNING)
 class TestApi(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
+        # Can't use a regular skip here, due to a Nose bug:
+        # https://github.com/nose-devs/nose/issues/946
+        if database_disabled():
+            raise unittest.SkipTest("Database functionality disabled "
+                                    "in configuration.")
         cls.db = tkp.db.Database()
         cls.db.connect()
 

--- a/tests/test_database/test_band.py
+++ b/tests/test_database/test_band.py
@@ -104,6 +104,7 @@ class TestBand(unittest.TestCase):
         phz_freq_image = Image(dataset=dataset, data=data)
         self.assertEqual(data['freq_eff'], get_freq_for_image(phz_freq_image))
 
+    @requires_database()
     def test_max_bandwidth(self):
         """
         Test if setting max bandwidth correctly affects the band of images

--- a/tests/test_database/test_delete.py
+++ b/tests/test_database/test_delete.py
@@ -2,6 +2,7 @@ import unittest
 from tkp.db.database import Database
 from tkp.testutil.alchemy import gen_dataset, gen_image, gen_band,\
     gen_skyregion, gen_runningcatalog, gen_extractedsource
+from tkp.testutil.decorators import requires_database
 from tkp.db.model import Image
 
 import logging
@@ -11,6 +12,7 @@ logging.getLogger('sqlalchemy.engine').setLevel(logging.INFO)
 
 
 class TestDeleteDataset(unittest.TestCase):
+    @requires_database()
     def test_delete_dataset(self):
         db = Database()
         dataset = gen_dataset('delete test')

--- a/tests/test_database/test_expire.py
+++ b/tests/test_database/test_expire.py
@@ -20,6 +20,7 @@ from tkp.db.associations import _update_1_to_1_runcat
 from tkp.testutil.alchemy import gen_band, gen_dataset, gen_skyregion, \
     gen_extractedsource, gen_runningcatalog, gen_assocskyrgn, \
     gen_assocxtrsource, gen_image
+from tkp.testutil.decorators import database_disabled
 
 
 logging.basicConfig(level=logging.DEBUG)
@@ -29,6 +30,11 @@ logging.basicConfig(level=logging.DEBUG)
 class TestExpire(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
+        # Can't use a regular skip here, due to a Nose bug:
+        # https://github.com/nose-devs/nose/issues/946
+        if database_disabled():
+            raise unittest.SkipTest("Database functionality disabled "
+                                    "in configuration.")
         cls.database = Database()
         cls.database.connect()
 

--- a/tests/test_database/test_image_store.py
+++ b/tests/test_database/test_image_store.py
@@ -8,12 +8,14 @@ from tkp.db.model import Image
 from tkp.db.database import Database
 from tkp.testutil.data import DATAPATH
 from tkp.testutil.alchemy import gen_image
+from tkp.testutil.decorators import requires_database
 
 FITS_FILE = path.join(DATAPATH, 'accessors/aartfaac.fits')
 
 
 
 class TestImageStore(unittest.TestCase):
+    @requires_database()
     def setUp(self):
         self.db = Database()
         self.image = gen_image()

--- a/tests/test_database/test_sql/test_median.py
+++ b/tests/test_database/test_sql/test_median.py
@@ -2,10 +2,16 @@ import unittest
 import tkp
 from tkp.db import execute, Database
 from tkp.testutil import db_subs
+from tkp.testutil.decorators import database_disabled
 from numpy import median
 
 class testMedian(unittest.TestCase):
     def setUp(self):
+        # Can't use a regular skip here, due to a Nose bug:
+        # https://github.com/nose-devs/nose/issues/946
+        if database_disabled():
+            raise unittest.SkipTest("Database functionality disabled "
+                                    "in configuration.")
         self.database = tkp.db.Database()
 
         self.dataset = tkp.db.DataSet(database=self.database,

--- a/tests/test_database/test_version.py
+++ b/tests/test_database/test_version.py
@@ -1,10 +1,16 @@
 import unittest
 from tkp.db.model import Version, SCHEMA_VERSION
 from tkp.db.database import Database
+from tkp.testutil.decorators import database_disabled
 
 
 class TestVersion(unittest.TestCase):
     def setUp(self):
+        # Can't use a regular skip here, due to a Nose bug:
+        # https://github.com/nose-devs/nose/issues/946
+        if database_disabled():
+            raise unittest.SkipTest("Database functionality disabled "
+                                    "in configuration.")
         self.database = Database()
         self.database.connect()
 

--- a/tests/test_steps/test_varmetric.py
+++ b/tests/test_steps/test_varmetric.py
@@ -5,6 +5,7 @@ import tkp.db.model
 
 from tkp.testutil.alchemy import gen_band, gen_dataset, gen_skyregion,\
     gen_lightcurve
+from tkp.testutil.decorators import database_disabled
 
 import tkp.db
 
@@ -18,6 +19,11 @@ logging.getLogger('sqlalchemy.engine').setLevel(logging.WARNING)
 class TestApi(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
+        # Can't use a regular skip here, due to a Nose bug:
+        # https://github.com/nose-devs/nose/issues/946
+        if database_disabled():
+            raise unittest.SkipTest("Database functionality disabled "
+                                    "in configuration.")
         cls.db = tkp.db.Database()
         cls.db.connect()
 

--- a/tkp/testutil/decorators.py
+++ b/tkp/testutil/decorators.py
@@ -2,8 +2,13 @@ import os
 import unittest
 
 
+def database_disabled():
+    """Return ``True`` if the database is disabled for test purposes."""
+    return os.environ.get("TKP_DISABLEDB", False)
+
+
 def requires_database():
-    if os.environ.get("TKP_DISABLEDB", False):
+    if database_disabled():
         return unittest.skip("Database functionality disabled in configuration")
     return lambda func: func
 


### PR DESCRIPTION
This means that if I

- Don't have any database set up; and
- ``export TKP_DBDISABLED=1``

I can get a clean run of the test suite:

  Ran 376 tests in 543.274s
  OK (SKIP=102)

(Previously, I was seeing many database connection errors.)