### PR TITLE
Updated versions of python modules sqlalchemy and casacore

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,11 @@ install_requires = """
     colorlog
     numpy>=1.3.0,<1.17.0
     psycopg2
-    python-casacore
+    python-casacore==3.3.0
     python-dateutil>=1.4.1
     pytz
     scipy>=0.7.0,<1.3.0
-    sqlalchemy>=1.0.0
+    sqlalchemy>=1.0.0,<1.4.0
     alembic
     monotonic
     """.split()


### PR DESCRIPTION
Specifying which versions of casacore and sqlalchemy are to be installed with the TraP. This solves a number of errors produced by the TraP master branch. It also ensures that all TraP tests are passed. See issues #583 and #586.

When upgrading to python 3.0, we should reconsider how we solve this issue to enable the latest versions to be used again. See issue #371 