### PR TITLE
Fixing the quality control tests for all images

### DIFF
--- a/tkp/config/job_template/job_params.cfg
+++ b/tkp/config/job_template/job_params.cfg
@@ -8,6 +8,8 @@ rms_est_max = 100            ; global maximum acceptable rms
 rms_est_min = 0.0            ; global minimum acceptable rms
 rms_rej_sigma = 3	     ; threshold for rejecting images using rms histogram
 bandwidth_max = 0.0          ; if non zero override bandwidth of image, determines which images fall in same band
+oversampled_x = 30           ; threshold for oversampled check
+elliptical_x = 2.0           ; threshold for elliptical check
 
 [quality_lofar]
 low_bound = 1                ; multiplied with noise to define lower threshold

--- a/tkp/config/job_template/job_params.cfg
+++ b/tkp/config/job_template/job_params.cfg
@@ -6,6 +6,7 @@ rms_est_fraction = 8         ; Determines size of image subsection used for RMS 
 rms_est_history = 100        ; how many images used for calculating rms histogram
 rms_est_max = 100            ; global maximum acceptable rms
 rms_est_min = 0.0            ; global minimum acceptable rms
+rms_rej_sigma = 3	     ; threshold for rejecting images using rms histogram
 bandwidth_max = 0.0          ; if non zero override bandwidth of image, determines which images fall in same band
 
 [quality_lofar]

--- a/tkp/main.py
+++ b/tkp/main.py
@@ -201,11 +201,12 @@ def quality_check(db_images, accessors, job_config, runner):
     rms_max = job_config.persistence.rms_est_max
     rms_min = job_config.persistence.rms_est_min
     est_sigma = job_config.persistence.rms_est_sigma
+    rej_sigma = job.config.persistence.rms_rej_sigma
     good_images = []
     for db_image, rejected, accessor in zip(db_images, rejecteds, accessors):
         if not rejected:
             rejected = reject_historical_rms(db_image.id, db.session,
-                                             history, est_sigma, rms_max, rms_min)
+                                             history, est_sigma, rms_max, rms_min, rej_sigma)
 
         if rejected:
             reason, comment = rejected

--- a/tkp/main.py
+++ b/tkp/main.py
@@ -237,7 +237,7 @@ def quality_check_all(db_images, accessors, job_config,runner):
     for db_image, rejected, accessor in zip(db_images, rejecteds, accessors):
         if not rejected:
             rejected = reject_basic_rms(db_image.id, db.session,
-                                        history, est_sigma, rms_max, rms_min)
+                                         est_sigma, rms_max, rms_min)
 
         if rejected:
             reason, comment = rejected

--- a/tkp/main.py
+++ b/tkp/main.py
@@ -201,7 +201,7 @@ def quality_check(db_images, accessors, job_config, runner):
     rms_max = job_config.persistence.rms_est_max
     rms_min = job_config.persistence.rms_est_min
     est_sigma = job_config.persistence.rms_est_sigma
-    rej_sigma = job.config.persistence.rms_rej_sigma
+    rej_sigma = job_config.persistence.rms_rej_sigma
     good_images = []
     for db_image, rejected, accessor in zip(db_images, rejecteds, accessors):
         if not rejected:

--- a/tkp/main.py
+++ b/tkp/main.py
@@ -244,7 +244,7 @@ def quality_check_all(db_images, accessors, job_config,runner):
                                          est_sigma, rms_max, rms_min)
         if not rejected:
             (semimaj, semimin, theta) = accessor.beam
-            rejected = check_beam(semimaj, semimin, theta, oversampled_x, elliptical_x)
+            rejected = reject_beam(semimaj, semimin, theta, oversampled_x, elliptical_x)
 
         if rejected:
             reason, comment = rejected

--- a/tkp/main.py
+++ b/tkp/main.py
@@ -30,6 +30,7 @@ from tkp.stream import stream_generator
 from tkp.quality.rms import reject_historical_rms
 from tkp.quality.rms import reject_basic_rms
 from tkp.quality.restoringbeam import reject_beam
+from tkp.accessors.dataaccessor import degrees2pixels
 
 logger = logging.getLogger(__name__)
 
@@ -244,7 +245,9 @@ def quality_check_all(db_images, accessors, job_config,runner):
                                          est_sigma, rms_max, rms_min)
         if not rejected:
             (semimaj, semimin, theta) = accessor.beam
-            rejected = reject_beam(semimaj, semimin, theta, oversampled_x, elliptical_x)
+            (deltax, deltay) = accessor.wcs.cdelt
+            (semimaj_pix, semimin_pix, theta) = degrees2pixels(semimaj,semimin,theta,deltax,deltay)
+            rejected = reject_beam(semimaj_pix, semimin_pix, theta, oversampled_x, elliptical_x)
 
         if rejected:
             reason, comment = rejected

--- a/tkp/main.py
+++ b/tkp/main.py
@@ -28,7 +28,7 @@ import tkp.steps.forced_fitting as steps_ff
 from tkp.steps.varmetric import execute_store_varmetric
 from tkp.stream import stream_generator
 from tkp.quality.rms import reject_historical_rms
-
+from tkp.quality.rms import reject_basic_rms
 
 logger = logging.getLogger(__name__)
 
@@ -436,7 +436,7 @@ def run_batch(image_paths, job_config, runner, dataset_id, copy_images):
     sorting_metadata = get_metadata_for_sorting(runner, image_paths)
     grouped_images = group_per_timestep(sorting_metadata)
 
-    accessors = get_accessors(runner,images)
+    accessors = get_accessors(runner,image_paths)
     metadatas = extract_metadata(job_config, accessors,runner)
     db_images = store_image_metadata(metadatas, job_config, dataset_id)
     error = "%s != %s != %s" % (len(accessors), len(metadatas), len(db_images))

--- a/tkp/main.py
+++ b/tkp/main.py
@@ -244,7 +244,7 @@ def quality_check_all(db_images, accessors, job_config,runner):
                                          est_sigma, rms_max, rms_min)
         if not rejected:
             (semimaj, semimin, theta) = accessor.beam
-            logger.info(semimaj,semimin,theta)
+            logger.info("{}, {}, {}".format(semimaj,semimin,theta))
             rejected = reject_beam(semimaj, semimin, theta, oversampled_x, elliptical_x)
 
         if rejected:
@@ -348,7 +348,7 @@ def store_image_data(db_images, fits_datas, fits_headers):
     store_fits(db_images, fits_datas, fits_headers)
 
 
-def timestamp_step(runner, images, job_config, dataset_id, copy_images):
+def timestamp_step(runner, images, job_config, dataset_id, copy_images, accessors, metadatas, db_images):
     """
     Called from the main loop with all images in a certain timestep
 
@@ -362,12 +362,12 @@ def timestamp_step(runner, images, job_config, dataset_id, copy_images):
     returns:
         tuple: of tuples (rms_qc, band)
     """
-    # gather all image info
-    accessors = get_accessors(runner, images)
-    metadatas = extract_metadata(job_config, accessors, runner)
-    db_images = store_image_metadata(metadatas, job_config, dataset_id)
-    error = "%s != %s != %s" % (len(accessors), len(metadatas), len(db_images))
-    assert len(accessors) == len(metadatas) == len(db_images), error
+    ## gather all image info
+    #accessors = get_accessors(runner, images)
+    #metadatas = extract_metadata(job_config, accessors, runner)
+    #db_images = store_image_metadata(metadatas, job_config, dataset_id)
+    #error = "%s != %s != %s" % (len(accessors), len(metadatas), len(db_images))
+    #assert len(accessors) == len(metadatas) == len(db_images), error
 
     # store copy of image data in database
     if copy_images:
@@ -456,7 +456,7 @@ def run_batch(image_paths, job_config, runner, dataset_id, copy_images):
         msg = "processing %s images in timestep %s (%s/%s)"
         logger.info(msg % (len(images), timestep, n + 1, len(grouped_images)))
         try:
-            timestamp_step(runner, images, job_config, dataset_id, copy_images)
+            timestamp_step(runner, images, job_config, dataset_id, copy_images, accessors, metadatas, db_images)
         except Exception as e:
             logger.error("timestep raised {} exception: {}".format(type(e), str(e)))
 

--- a/tkp/main.py
+++ b/tkp/main.py
@@ -30,7 +30,6 @@ from tkp.stream import stream_generator
 from tkp.quality.rms import reject_historical_rms
 from tkp.quality.rms import reject_basic_rms
 from tkp.quality.restoringbeam import reject_beam
-from tkp.accessors.dataaccessor import degrees2pixels
 
 logger = logging.getLogger(__name__)
 
@@ -245,9 +244,8 @@ def quality_check_all(db_images, accessors, job_config,runner):
                                          est_sigma, rms_max, rms_min)
         if not rejected:
             (semimaj, semimin, theta) = accessor.beam
-            (deltax, deltay) = accessor.wcs.cdelt
-            (semimaj_pix, semimin_pix, theta) = degrees2pixels(semimaj,semimin,theta,deltax,deltay)
-            rejected = reject_beam(semimaj_pix, semimin_pix, theta, oversampled_x, elliptical_x)
+            logger.info(semimaj,semimin,theta)
+            rejected = reject_beam(semimaj, semimin, theta, oversampled_x, elliptical_x)
 
         if rejected:
             reason, comment = rejected

--- a/tkp/quality/restoringbeam.py
+++ b/tkp/quality/restoringbeam.py
@@ -1,5 +1,6 @@
 import tkp.quality
 from tkp.utility import nice_format
+from tkp.db.quality import reject_reasons
 
 
 def undersampled(semibmaj, semibmin):
@@ -93,10 +94,7 @@ def beam_invalid(semibmaj, semibmin, theta, oversampled_x=30, elliptical_x=2.0):
 
 def reject_beam(semimaj, semimin, theta, oversampled_x=30, elliptical_x=2.0):
     beam_check = beam_invalid(semimaj, semimin, theta, oversampled_x, elliptical_x)
-    if not beam_check:
-        logger.info("image %s accepted: semimaj: %s, semimin: %s" % (accessor.url,
-                                             nice_format(semimaj),
-                                             nice_format(semimin)))
+    if beam_check:
+        return reject_reasons['beam'],beam_check
     else:
-        logger.info("image %s REJECTED: %s " % (accessor.url, beam_check))
-        return (dbquality.reject_reasons['beam'], beam_check)
+        return False

--- a/tkp/quality/restoringbeam.py
+++ b/tkp/quality/restoringbeam.py
@@ -89,3 +89,14 @@ def beam_invalid(semibmaj, semibmin, theta, oversampled_x=30, elliptical_x=2.0):
 
     else:
         return False
+
+
+def check_beam(semimaj, semimin, theta, oversampled_x=30, elliptical_x=2.0):
+    beam_check = beam_invalid(semimaj, semimin, theta, oversampled_x, elliptical_x)
+    if not beam_check:
+        logger.info("image %s accepted: semimaj: %s, semimin: %s" % (accessor.url,
+                                             nice_format(semimaj),
+                                             nice_format(semimin)))
+    else:
+        logger.info("image %s REJECTED: %s " % (accessor.url, beam_check))
+        return (dbquality.reject_reasons['beam'], beam_check)

--- a/tkp/quality/restoringbeam.py
+++ b/tkp/quality/restoringbeam.py
@@ -91,7 +91,7 @@ def beam_invalid(semibmaj, semibmin, theta, oversampled_x=30, elliptical_x=2.0):
         return False
 
 
-def check_beam(semimaj, semimin, theta, oversampled_x=30, elliptical_x=2.0):
+def reject_beam(semimaj, semimin, theta, oversampled_x=30, elliptical_x=2.0):
     beam_check = beam_invalid(semimaj, semimin, theta, oversampled_x, elliptical_x)
     if not beam_check:
         logger.info("image %s accepted: semimaj: %s, semimin: %s" % (accessor.url,

--- a/tkp/quality/rms.py
+++ b/tkp/quality/rms.py
@@ -79,7 +79,7 @@ def rms_with_clipped_subregion(data, rms_est_sigma=3, rms_est_fraction=4):
     return rms(clip(subregion(data, rms_est_fraction), rms_est_sigma))
 
 
-def reject_historical_rms(image_id, session, history=100, est_sigma=4, rms_max=100., rms_min=0.0):
+def reject_historical_rms(image_id, session, history=100, est_sigma=4, rms_max=100., rms_min=0.0, , rej_sigma=3):
     """
     Check if the RMS value of an image lies within a range defined
     by a gaussian fit on the histogram calculated from the last x RMS
@@ -103,8 +103,8 @@ def reject_historical_rms(image_id, session, history=100, est_sigma=4, rms_max=1
     if len(rmss) < history:
         return False
     mu, sigma = norm.fit(rmss)
-    t_low = mu - sigma * est_sigma
-    t_high = mu + sigma * est_sigma
+    t_low = mu - sigma * rej_sigma
+    t_high = mu + sigma * rej_sigma
 
     if not rms_min < image.rms_qc < rms_max:
         return reject_reasons['rms'],\

--- a/tkp/quality/rms.py
+++ b/tkp/quality/rms.py
@@ -108,7 +108,7 @@ def reject_historical_rms(image_id, session, history=100, est_sigma=4, rms_max=1
 
     if not rms_min < image.rms_qc < rms_max:
         return reject_reasons['rms'],\
-               "RMS value not within {} and {}".format(0.0, rms_max)
+               "RMS value not within {} and {}".format(rms_min, rms_max)
 
     if not t_low < image.rms_qc < t_high or not rms_min < image.rms_qc < rms_max:
         return reject_reasons['rms'],\

--- a/tkp/quality/rms.py
+++ b/tkp/quality/rms.py
@@ -79,7 +79,7 @@ def rms_with_clipped_subregion(data, rms_est_sigma=3, rms_est_fraction=4):
     return rms(clip(subregion(data, rms_est_fraction), rms_est_sigma))
 
 
-def reject_historical_rms(image_id, session, history=100, est_sigma=4, rms_max=100., rms_min=0.0, rej_sigma=3):
+def reject_historical_rms(image_id, session, history=100, est_sigma=4, rms_max=100., rms_min=0.0, rej_sigma=3.0):
     """
     Check if the RMS value of an image lies within a range defined
     by a gaussian fit on the histogram calculated from the last x RMS
@@ -110,7 +110,7 @@ def reject_historical_rms(image_id, session, history=100, est_sigma=4, rms_max=1
         return reject_reasons['rms'],\
                "RMS value not within {} and {}".format(0.0, rms_max)
 
-    if not t_low < image.rms_qc < t_high or not 0.0 < image.rms_qc < rms_max:
+    if not t_low < image.rms_qc < t_high or not rms_min < image.rms_qc < rms_max:
         return reject_reasons['rms'],\
                "RMS value not within {} and {}".format(t_low, t_high)
 

--- a/tkp/quality/rms.py
+++ b/tkp/quality/rms.py
@@ -78,7 +78,7 @@ def rms_with_clipped_subregion(data, rms_est_sigma=3, rms_est_fraction=4):
     """
     return rms(clip(subregion(data, rms_est_fraction), rms_est_sigma))
 
-def reject_basic_rms(db_image.id, db.session, est_sigma=4, rms_max=100., rms_min=0.0):
+def reject_basic_rms(image_id, session, est_sigma=4, rms_max=100., rms_min=0.0):
     """Check if the RMS value of an image lies within a range predetermined
     at the start of a pipeline run.
     

--- a/tkp/quality/rms.py
+++ b/tkp/quality/rms.py
@@ -78,6 +78,27 @@ def rms_with_clipped_subregion(data, rms_est_sigma=3, rms_est_fraction=4):
     """
     return rms(clip(subregion(data, rms_est_fraction), rms_est_sigma))
 
+def reject_basic_rms(db_image.id, db.session, est_sigma=4, rms_max=100., rms_min=0.0):
+    """Check if the RMS value of an image lies within a range predetermined
+    at the start of a pipeline run.
+    
+    args:
+        image_id (int): database ID of the image we want to check
+        session (sqlalchemy.orm.session.Session): the database session
+        est_sigma (float): sigma multiplication factor
+        rms_max (float): global maximum rms for image quality check
+        rms_min (float): global minimum rms for image quality check
+    returns:
+        bool: None if not rejected, (rejectreason, comment) if rejected
+    """
+
+    image = session.query(Image).filter(Image.id == image_id).one()
+
+    if not rms_min < image.rms_qc < rms_max:
+        return reject_reasons['rms'],\
+               "RMS value not within {} and {}".format(rms_min, rms_max)
+
+
 
 def reject_historical_rms(image_id, session, history=100, est_sigma=4, rms_max=100., rms_min=0.0, rej_sigma=3.0):
     """

--- a/tkp/quality/rms.py
+++ b/tkp/quality/rms.py
@@ -79,7 +79,7 @@ def rms_with_clipped_subregion(data, rms_est_sigma=3, rms_est_fraction=4):
     return rms(clip(subregion(data, rms_est_fraction), rms_est_sigma))
 
 
-def reject_historical_rms(image_id, session, history=100, est_sigma=4, rms_max=100., rms_min=0.0, , rej_sigma=3):
+def reject_historical_rms(image_id, session, history=100, est_sigma=4, rms_max=100., rms_min=0.0, rej_sigma=3):
     """
     Check if the RMS value of an image lies within a range defined
     by a gaussian fit on the histogram calculated from the last x RMS


### PR DESCRIPTION
This incorporates beam checks and comparison to the estimated max/min rms values for all images. It also corrects the sigma used in the historical rms check. It completes Issue #512  and partially completes Issue #588 

However, it leaves a remaining issue about the historical rms check for batch mode.