### PR TITLE
Fixes #608 AssertionError, Multiproc error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = """
     python-dateutil
     pytz
     scipy
-    sqlalchemy
+    sqlalchemy==1.4
     alembic
     monotonic
     psutil

--- a/tkp/main.py
+++ b/tkp/main.py
@@ -1,8 +1,8 @@
 """
 The main pipeline logic, from where all other components are called.
 """
-import imp
 import importlib
+from importlib.machinery import SourceFileLoader
 import logging
 import atexit
 import os
@@ -97,7 +97,8 @@ def load_images(job_name, job_dir):
         tuple: a list of paths
     """
     path = os.path.join(job_dir, 'images_to_process.py')
-    images = imp.load_source('images_to_process', path).images
+    images = SourceFileLoader('images_to_process', 
+                              path).load_module().images
     logger.info("dataset %s contains %s images" % (job_name,
                                                    len(images)))
     return images


### PR DESCRIPTION
Fixes #608 : "Daemonic processes are not allowed to have children". 

Also replaces the deprecated imp library.

Parts of the source extraction process have been parallellised, to speed things up.
For measuring all the islands that constitute sources, Python's multiprocessing has been applied. This was causing an AssertionError if we have `method = "multiproc"`  in pipeline.cfg.

All unit tests pass and `trap-manage.py run job` on a set of images will work as well.

@AntoniaR I guess this PR should be reviewed after #605 has been merged since that has been pending for a while.
