### PR TITLE
Fixes SAWarning #597

### DIFF
--- a/tkp/db/model.py
+++ b/tkp/db/model.py
@@ -334,10 +334,6 @@ class Runningcatalog(Base):
     mon_src = Column(Boolean, nullable=False, server_default=text("false"))
     forcedfits_count = Column(Integer, server_default=text("0"))
 
-    extractedsources = relationship('Extractedsource',
-                                    secondary='assocxtrsource',
-                                    backref='runningcatalogs')
-
     varmetric = relationship("Varmetric", uselist=False, backref="runcat",
                              cascade="all,delete")
 


### PR DESCRIPTION
This is removal of [line 337 in model.py](https://github.com/transientskp/tkp/blob/7a1a175b7205aac13d559de0afd1a02637f83a05/tkp/db/model.py#L337):

```
    extractedsources = relationship('Extractedsource',
                                    secondary='assocxtrsource',
                                    backref='runningcatalogs')
```
This in fact issues two relationships which may be redundant given [line 311](https://github.com/transientskp/tkp/blob/7a1a175b7205aac13d559de0afd1a02637f83a05/tkp/db/model.py#LL311C1-L313C85):
```
    xtrsrc = relationship('Extractedsource',
                          primaryjoin='Runningcatalog.xtrsrc_id == Extractedsource.id',
                          backref=backref('extractedsources', cascade="all,delete"))
```
This fixes #597, please read that discussion.